### PR TITLE
Grant cleanup

### DIFF
--- a/app/controllers/grants/duplicate_controller.rb
+++ b/app/controllers/grants/duplicate_controller.rb
@@ -11,7 +11,7 @@ module Grants
       @grant = GrantServices::CopyAttributes.call(@original_grant.id)
       @grant.valid?
       flash[:warning] = 'Information from ' + @original_grant.name + ' has been copied below.'
-      flash[:alert]   = 'Please review and update the following information'
+      flash[:alert]   = 'Please review and update the following information.'
     end
 
     def create
@@ -19,8 +19,9 @@ module Grants
       authorize @original_grant, :edit?
 
       @grant = Grant.new(grant_params)
-      @grant.duplicate = true
-      @grant.state     = 'draft'
+      @grant.duplicate       = true
+      @grant.state           = 'draft'
+      @grant.organization_id = current_user.organization_id
 
       result = GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @grant)
 

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -39,8 +39,9 @@ class GrantsController < ApplicationController
   # POST /grants
   # POST /grants.json
   def create
-    @grant = Grant.new(grant_params)
     authorize Grant, :create?
+    @grant = Grant.new(grant_params)
+    @grant.organization_id = current_user.organization_id
     set_state
     result = GrantServices::New.call(grant: @grant, user: current_user)
     if result.success?
@@ -109,7 +110,6 @@ class GrantsController < ApplicationController
       :max_proposals_per_reviewer,
       :panel_date,
       :panel_location,
-      :organization_id,
       :draft,
       :duplicate
     )

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,7 @@ class HomeController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @grants = Grants::HomeDecorator.decorate_collection(Grant.public_grants)
+    @grants = Grants::PublicDecorator.decorate_collection(Grant.public_grants)
     skip_authorization
   end
 end

--- a/app/decorators/grant_decorator.rb
+++ b/app/decorators/grant_decorator.rb
@@ -30,6 +30,10 @@ class GrantDecorator < Draper::Decorator
     h.content_tag(:li, view_submissions_link, class: "submissions-link", id: "submissions-#{h.dom_id(object)}") if h.policy(object).grant_viewer_access?
   end
 
+  def submission_period
+    "#{submission_open_date} - #{submission_close_date}"
+  end
+
   private
 
   def show_link

--- a/app/decorators/grants/public_decorator.rb
+++ b/app/decorators/grants/public_decorator.rb
@@ -1,13 +1,9 @@
 module Grants
-  class HomeDecorator < Draper::Decorator
+  class PublicDecorator < Draper::Decorator
     delegate_all
 
     def initialize(*args)
       super(GrantDecorator.new(*args))
-    end
-
-    def submission_period
-      "#{submission_open_date} - #{submission_close_date}"
     end
 
     def edit_menu_link

--- a/app/views/grants/_form.html.haml
+++ b/app/views/grants/_form.html.haml
@@ -80,15 +80,14 @@
     = f.text_area :panel_location, cols: 15, rows: 5, placeholder: 'Required if Panel Day is set. Use TBD if unknown.'
 
 .grid-x
-  = f.hidden_field :organization_id, value: current_user.organization.id
   .actions
-    = f.submit 'Save as Draft', class: 'button warning', name: 'draft', confirm: 'Drafts will not become visible until Completed'
-    - if grant.persisted?
-      = f.submit 'Save and Publish', class: 'button'
-      = link_to 'Cancel', grant, class: 'button secondary clear'
-      = link_to 'Delete', grant, method: :delete, data: { confirm: 'Are you sure?'}, class: 'button alert clear'
-    - else
+    - if grant.new_record? || grant.draft?
+      = f.submit 'Save as Draft', class: 'button warning', name: 'draft', confirm: 'Drafts will not become visible until Completed'
       = link_to 'Cancel', grants_path, class: 'button secondary clear'
+    - else
+      = f.submit 'Update', class: 'button'
+      = link_to 'Cancel', grant, class: 'button secondary clear'
+    = link_to 'Delete', grant, method: :delete, data: { confirm: 'Are you sure?'}, class: 'button alert clear'
 
 :javascript
   $(function() {

--- a/spec/decorators/grants/public_decorator_spec.rb
+++ b/spec/decorators/grants/public_decorator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Grants::HomeDecorator do
+RSpec.describe Grants::PublicDecorator do
   before do
     @open_grant = create(:open_grant_with_users_and_questions)
   end
@@ -11,7 +11,7 @@ RSpec.describe Grants::HomeDecorator do
     before(:each) do
       @user = create(:user)
       sign_in @user
-      @decorated_open_grant = Grants::HomeDecorator.decorate(@open_grant)
+      @decorated_open_grant = Grants::PublicDecorator.decorate(@open_grant)
     end
 
     it 'does not generate an edit link' do
@@ -24,16 +24,13 @@ RSpec.describe Grants::HomeDecorator do
       expect(@decorated_open_grant.apply_menu_link).to have_css("a#apply-grant_#{@open_grant.id}-link", text: 'Apply Now')
     end
 
-    it 'formats submission dates ' do
-      expect(@decorated_open_grant.submission_period).to eql("#{@open_grant.submission_open_date} - #{@open_grant.submission_close_date}")
-    end
   end
 
   context 'user with no roles' do
     before(:each) do
       @admin_user = @open_grant.grant_users.grant_role_admin.first.user
       sign_in @admin_user
-      @decorated_open_grant = Grants::HomeDecorator.decorate(@open_grant)
+      @decorated_open_grant = Grants::PublicDecorator.decorate(@open_grant)
     end
 
     it 'generates an edit link' do
@@ -45,10 +42,6 @@ RSpec.describe Grants::HomeDecorator do
       expect(@decorated_open_grant.apply_menu_link).to have_css("li#apply-grant_#{@open_grant.id}")
       expect(@decorated_open_grant.apply_menu_link).to have_css("a#apply-grant_#{@open_grant.id}-link", text: 'Apply Now')
     end
-
-    it 'formats submission dates ' do
-      expect(@decorated_open_grant.submission_period).to eql("#{@open_grant.submission_open_date} - #{@open_grant.submission_close_date}")
-    end
   end
 
   # TODO: Allow for unauthorized user in test
@@ -56,8 +49,7 @@ RSpec.describe Grants::HomeDecorator do
   pending 'unauthenticated user' do
     before(:each) do
       sign_in nil
-      @decorated_open_grant = Grants::HomeDecorator.decorate(@open_grant)
+      @decorated_open_grant = Grants::PublicDecorator.decorate(@open_grant)
     end
   end
-
 end

--- a/spec/system/grants/grants_spec.rb
+++ b/spec/system/grants/grants_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Grants', type: :system do
 
       expect(page).to have_field('grant_publish_date', with: @grant.publish_date)
       page.execute_script("$('#grant_publish_date').fdatepicker('setDate',new Date('#{tomorrow}'))")
-      click_button 'Save and Publish'
+      click_button 'Update'
 
       expect(@grant.reload.publish_date.to_s).to eql(tomorrow)
     end
@@ -47,7 +47,7 @@ RSpec.describe 'Grants', type: :system do
     scenario 'versioning tracks whodunnit', versioning: true do
       expect(PaperTrail).to be_enabled
       fill_in 'grant_name', with: 'New_Name'
-      click_button 'Save and Publish'
+      click_button 'Update'
 
       expect(page).to have_content 'Grant was successfully updated.'
       expect(@grant.versions.last.whodunnit).to eql(@admin_user.id)
@@ -55,7 +55,7 @@ RSpec.describe 'Grants', type: :system do
 
     scenario 'invalid submission', versioning: true do
       page.fill_in 'Close Date', with: (@grant.submission_open_date - 1.day)
-      click_button 'Save as Draft'
+      click_button 'Update'
       expect(page).to have_content 'Submission close date must be after the opening date for submissions.'
     end
   end
@@ -88,7 +88,6 @@ RSpec.describe 'Grants', type: :system do
 
     scenario 'valid form submission creates constraints and permissions' do
       click_button 'Save as Draft'
-
       grant = Grant.last
       expect(grant.name).to eql(@grant.name)
       expect(page.current_path).to eq(grant_questions_path(grant))
@@ -171,6 +170,7 @@ RSpec.describe 'Grants', type: :system do
       page.fill_in 'Review Open Date', with: @grant.review_open_date + 1.day
       page.fill_in 'Review Close Date', with: @grant.review_close_date + 1.day
 
+      byebug
       expect do
         click_button('Save as Draft')
       end.to change{ Grant.count }.by(1).and change{ GrantUser.count}.by(@grant.grant_users.count).and change{ Question.count}.by(@grant.questions.count)


### PR DESCRIPTION
* Remove organization_id from grant form
* Change name of Grants::HomeDecorator to Grants::PublicDecorator
* Move submission_period method to GrantsDecorator
* Remove "Save and Publish" and "Save as Draft" buttons on Grant edit. Replace with "Update" button.