### PR TITLE
Refactor after code review

### DIFF
--- a/app/controllers/grants/state_controller.rb
+++ b/app/controllers/grants/state_controller.rb
@@ -12,9 +12,8 @@ module Grants
           format.html { redirect_back fallback_location: grant_path(@grant),
                         notice: "Publish status was changed to #{@grant.state}." }
         else
-          # TODO: test this
           format.html { redirect_back fallback_location: grant_path(@grant),
-                        warning: 'Status change failed.' }
+                        alert: "Status change failed. This grant is still in #{@grant.state} mode." }
         end
       end
     end

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -4,7 +4,6 @@ class GrantsController < ApplicationController
   include WithGrantRoles
 
   before_action :set_grant,    except: %i[index new create]
-  before_action :set_state,    only: %i[update]
 
   # GET /grants
   # GET /grants.json
@@ -42,12 +41,11 @@ class GrantsController < ApplicationController
     authorize Grant, :create?
     @grant = Grant.new(grant_params)
     @grant.organization_id = current_user.organization_id
-    set_state
     result = GrantServices::New.call(grant: @grant, user: current_user)
     if result.success?
       # TODO: Confirm messages the user should see
       flash[:notice]  = 'Grant saved.'
-      flash[:warning] = 'Review Questions below then click "Save and Publish" to finalize.'
+      flash[:warning] = 'Review Questions below then click "Publish this Grant" to finalize.'
       redirect_to grant_questions_url(@grant)
     else
       respond_to do |format|
@@ -96,7 +94,6 @@ class GrantsController < ApplicationController
     params.require(:grant).permit(
       :name,
       :slug,
-      :state,
       :default_set,
       :publish_date,
       :submission_open_date,
@@ -110,17 +107,12 @@ class GrantsController < ApplicationController
       :max_proposals_per_reviewer,
       :panel_date,
       :panel_location,
-      :draft,
       :duplicate
     )
   end
 
   def set_grant
     @grant = Grant.with_organization.friendly.find(params[:id])
-  end
-
-  def set_state
-    @grant.state = params[:draft].present? ? 'draft' : 'published'
   end
 
   def draft_banner

--- a/app/views/grants/_form.html.haml
+++ b/app/views/grants/_form.html.haml
@@ -12,7 +12,7 @@
       %label.middle
         http://example.org/
     .cell.small-12.medium-9
-      = f.text_field :slug, required: true, maxlength: 10, class: 'small-12 medium-6'
+      = f.text_field :slug, required: true, maxlength: Grant::SLUG_MAX_LENGTH, class: 'small-12 medium-6'
 .grid-x.grid-padding-y
   .cell
     = f.label :rfa, 'RFA'

--- a/db/migrate/20190115192633_create_grants.rb
+++ b/db/migrate/20190115192633_create_grants.rb
@@ -4,12 +4,12 @@ class CreateGrants < ActiveRecord::Migration[5.2]
   def change
     create_table :grants do |t|
       t.references :organization, foreign_key: true
-      t.string :name
-      t.string :slug
-      t.string :state
-      t.date :publish_date
-      t.date :submission_open_date
-      t.date :submission_close_date
+      t.string :name,                null: false
+      t.string :slug,                null: false
+      t.string :state,               null: false
+      t.date :publish_date,          null: false
+      t.date :submission_open_date,  null: false
+      t.date :submission_close_date, null: false
       t.text :rfa
       t.integer :applications_per_user
       t.text :review_guidance

--- a/spec/decorators/grants/public_decorator_spec.rb
+++ b/spec/decorators/grants/public_decorator_spec.rb
@@ -23,10 +23,9 @@ RSpec.describe Grants::PublicDecorator do
       expect(@decorated_open_grant.apply_menu_link).to have_css("li#apply-grant_#{@open_grant.id}")
       expect(@decorated_open_grant.apply_menu_link).to have_css("a#apply-grant_#{@open_grant.id}-link", text: 'Apply Now')
     end
-
   end
 
-  context 'user with no roles' do
+  context 'admin user' do
     before(:each) do
       @admin_user = @open_grant.grant_users.grant_role_admin.first.user
       sign_in @admin_user
@@ -44,12 +43,21 @@ RSpec.describe Grants::PublicDecorator do
     end
   end
 
-  # TODO: Allow for unauthorized user in test
-  #       https://github.com/plataformatec/devise/wiki/How-To:-Stub-authentication-in-controller-specs
-  pending 'unauthenticated user' do
+  context 'unauthenticated user' do
     before(:each) do
-      sign_in nil
       @decorated_open_grant = Grants::PublicDecorator.decorate(@open_grant)
+    end
+
+    it 'does not generate an edit link' do
+      allow(h).to receive(:user_signed_in?).and_return(false)
+      expect(@decorated_open_grant.edit_menu_link).not_to have_css("li#edit-grant_#{@open_grant.id}")
+      expect(@decorated_open_grant.edit_menu_link).not_to have_css("a#edit-grant_#{@open_grant.id}-link", text: 'Edit')
+    end
+
+    it 'generates an apply menu link' do
+      allow(h).to receive(:user_signed_in?).and_return(false)
+      expect(@decorated_open_grant.apply_menu_link).to have_css("li#apply-grant_#{@open_grant.id}")
+      expect(@decorated_open_grant.apply_menu_link).to have_css("a#apply-grant_#{@open_grant.id}-link", text: 'Apply Now')
     end
   end
 end

--- a/spec/factories/grant.rb
+++ b/spec/factories/grant.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     sequence(:name)             { |n| "Grant Name #{n}" }
     sequence(:slug)             { |n| "GN#{n}" }
     default_set                 { FactoryBot.create(:default_set).id }
-    state                       { 'published' }
     publish_date                { Date.current }
     submission_open_date        { 10.day.from_now }
     submission_close_date       { 20.days.from_now }
@@ -19,6 +18,10 @@ FactoryBot.define do
     review_close_date           { 40.days.from_now }
     panel_date                  { 50.days.from_now }
     panel_location              { Faker::Address.full_address }
+
+    trait :new do
+      state {  }
+    end
 
     trait :demo do
       state { 'demo' }
@@ -76,9 +79,10 @@ FactoryBot.define do
       to_create { |grant| grant.save(validate: false) }
     end
 
+    factory :new_grant,                                traits: %i[new]
     factory :draft_grant,                              traits: %i[draft]
     factory :published_grant,                          traits: %i[published]
-    factory :open_grant_with_users_and_questions,      traits: %i[open with_questions with_users]
+    factory :open_grant_with_users_and_questions,      traits: %i[published open with_questions with_users]
     factory :closed_grant_with_users_and_questions,    traits: %i[closed with_questions with_users]
     factory :published_open_grant,                     traits: %i[published open]
     factory :published_closed_grant,                   traits: %i[published closed]
@@ -86,7 +90,7 @@ FactoryBot.define do
     factory :completed_grant,                          traits: %i[completed closed]
     factory :draft_open_grant,                         traits: %i[draft open]
     factory :draft_closed_grant,                       traits: %i[draft closed]
-    factory :grant_with_users_and_questions,           traits: %i[with_questions with_users]
+    factory :grant_with_users_and_questions,           traits: %i[published with_questions with_users]
     factory :demo_grant_with_users_and_questions,      traits: %i[demo with_questions with_users]
     factory :draft_grant_with_users_and_questions,     traits: %i[draft with_questions with_users]
     factory :completed_grant_with_users_and_questions, traits: %i[completed with_questions with_users]

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Grant, type: :model do
 
       it 'does not require a default_set on update' do
         grant.save
+
         grant.default_set = nil
         expect(grant).to be_valid
       end
@@ -71,19 +72,19 @@ RSpec.describe Grant, type: :model do
         expect(new_grant.errors.messages[:slug]).to eq ['has already been taken']
       end
 
-      it 'requires a slug to be at least 3 characters long' do
-        grant.slug = "ab"
+      it "requires a slug to be at least #{Grant::SLUG_MIN_LENGTH} characters long" do
+        grant.slug = Faker::Alphanumeric.alpha(Grant::SLUG_MIN_LENGTH - 1)
         expect(grant).not_to be_valid
         expect(grant.errors).to include :slug
-        grant.slug = "abc"
+        grant.slug = Faker::Alphanumeric.alpha(Grant::SLUG_MIN_LENGTH)
         expect(grant).to be_valid
       end
 
-      it 'requires a slug to be at no more than 15 characters long' do
-        grant.slug = "abcdefghijklmnop"
+      it "requires a slug to be at no more than #{Grant::SLUG_MAX_LENGTH} characters long" do
+        grant.slug = Faker::Alphanumeric.alpha(Grant::SLUG_MAX_LENGTH + 1)
         expect(grant).not_to be_valid
         expect(grant.errors).to include :slug
-        grant.slug = "abcdefghijklmn0"
+        grant.slug = Faker::Alphanumeric.alpha(Grant::SLUG_MAX_LENGTH)
         expect(grant).to be_valid
       end
 
@@ -156,7 +157,7 @@ RSpec.describe Grant, type: :model do
     end
   end
 
-    describe 'SoftDeletable' do
+  describe 'SoftDeletable' do
     it 'cannot be destroyed' do
       expect{grant.destroy}.to raise_error(SoftDeleteException, 'Grants must be soft deleted.')
     end

--- a/spec/policies/grants_policy_spec.rb
+++ b/spec/policies/grants_policy_spec.rb
@@ -6,11 +6,11 @@ describe GrantPolicy do
   subject { described_class.new(user, grant) }
 
   context 'with user and grant of the same organization' do
-    let(:organization) { FactoryBot.create(:organization) }
-    let(:grant) { FactoryBot.create(:grant, organization: organization) }
+    let(:organization) { create(:organization) }
+    let(:grant)        { create(:published_grant, organization: organization) }
 
     context 'grants for organization none users' do
-      let(:user) { FactoryBot.create(:user) }
+      let(:user) { create(:user) }
 
       it { is_expected.to permit_action(:index) }
       it { is_expected.to permit_action(:show) }
@@ -23,7 +23,7 @@ describe GrantPolicy do
     end
 
     context 'grants for organization admin users' do
-      let(:user) { FactoryBot.create(:user, organization_role: 'admin', organization: organization) }
+      let(:user) { create(:user, organization_role: 'admin', organization: organization) }
 
       it { is_expected.to permit_action(:index) }
       it { is_expected.to permit_action(:show) }
@@ -37,18 +37,16 @@ describe GrantPolicy do
   end
   context 'with user and grant of different organizations' do
     context 'grants for organization admin users' do
-      let(:organization1) { FactoryBot.create(:organization) }
-      let(:organization2) { FactoryBot.create(:organization) }
-      let(:grant) { FactoryBot.create(:grant, organization: organization1) }
-      let(:user) { FactoryBot.create(:user, organization_role: 'admin', organization: organization2) }
+      let(:organization1) { create(:organization) }
+      let(:organization2) { create(:organization) }
+      let(:grant)         { create(:published_grant, organization: organization1) }
+      let(:user)          { create(:user, organization_role: 'admin', organization: organization2) }
 
       it { is_expected.to permit_action(:index) }
       it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:new) }
-      # We have stopped checking org.
       it { is_expected.to permit_action(:create) }
 
-      # These actions are only allowed with grant access.
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }

--- a/spec/system/grants/grants_spec.rb
+++ b/spec/system/grants/grants_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe 'Grants', type: :system do
   describe 'New', js: true do
     before(:each) do
       @default_set  = create(:default_set, :with_questions)
-      @grant        = build(:grant)
+      @grant        = build(:new_grant)
       @user         = create(:user, organization: @grant.organization,
-                                               organization_role: 'admin')
+                                    organization_role: 'admin')
       login_as(@user)
 
       visit new_grant_path

--- a/spec/system/grants/state_spec.rb
+++ b/spec/system/grants/state_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe 'Grants', type: :system do
         expect(page).to have_content 'Current Publish Status: Draft'
         expect(page).to have_content 'Publish status was changed to draft.'
       end
+
+      scenario 'displays error on failure' do
+        allow_any_instance_of(Grant).to receive(:update).and_return(false)
+        click_button 'Switch to Draft'
+        expect(page).to have_content 'Status change failed. This grant is still in published mode.'
+      end
     end
 
     context 'grant editor user' do
@@ -43,6 +49,12 @@ RSpec.describe 'Grants', type: :system do
         click_button 'Switch to Draft'
         expect(page).to have_content 'Current Publish Status: Draft'
         expect(page).to have_content 'Publish status was changed to draft.'
+      end
+
+      scenario 'displays error on failure' do
+        allow_any_instance_of(Grant).to receive(:update).and_return(false)
+        click_button 'Switch to Draft'
+        expect(page).to have_content 'Status change failed. This grant is still in published mode.'
       end
     end
   end
@@ -71,11 +83,10 @@ RSpec.describe 'Grants', type: :system do
         expect(page).to have_content 'Publish status was changed to published.'
       end
 
-      pending 'failure' do
-        fail 'add failed status change'
+      scenario 'displays error on failure' do
+        allow_any_instance_of(Grant).to receive(:update).and_return(false)
         click_button 'Publish this Grant'
-        expect(@draft_grant).to receive(:update).and_return false
-        expect(page).to have_content 'Current Publish Status: Draft'
+        expect(page).to have_content 'Status change failed. This grant is still in draft mode.'
       end
     end
 
@@ -94,6 +105,12 @@ RSpec.describe 'Grants', type: :system do
         click_button 'Publish this Grant'
         expect(page).to have_content 'Current Publish Status: Published'
         expect(page).to have_content 'Publish status was changed to published.'
+      end
+
+      scenario 'displays error on failure' do
+        allow_any_instance_of(Grant).to receive(:update).and_return(false)
+        click_button 'Publish this Grant'
+        expect(page).to have_content 'Status change failed. This grant is still in draft mode.'
       end
     end
   end


### PR DESCRIPTION
- Set default Grant state to draft on new_record
  - Remove set_state from Grants controller
- Add null false to required columns in Grant
- Finalize pending specs:
  - Failed status change Grant system spec
  - Unauthorized user Grant PublicDecorator specs
- Remove 'published' state from default Grant factory
- Add new_grant factory
- Add constants for slug minimum and maximum length 