### PR TITLE
Fix review un-/assign permission for grant editors

### DIFF
--- a/app/policies/review_policy.rb
+++ b/app/policies/review_policy.rb
@@ -39,7 +39,9 @@ class ReviewPolicy < GrantPolicy
     record
   end
 
-  private
+  def grant
+    record.grant
+  end
 
   def current_user_is_reviewer?
     review.reviewer == user


### PR DESCRIPTION
Fixes bug where grant admins and editors were unable to assign and unassign reviews.