### PR TITLE
system-admin-accessible checkboxes for user roles

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,6 +42,9 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:era_commons)
+    user_params = [:era_commons]
+    user_params << %i[system_admin grant_creator] if current_user.system_admin?
+
+    params.require(:user).permit(user_params)
   end
 end

--- a/app/views/users/_admin_checkboxes.html.haml
+++ b/app/views/users/_admin_checkboxes.html.haml
@@ -1,0 +1,11 @@
+.grid-x
+  .cell.small-12
+    - if user.grant_creator_requests.pending.any?
+      = link_to 'Pending Grant Creator Request', grant_creator_requests_path
+    - else
+      = f.check_box :grant_creator
+      = f.label :grant_creator, 'Grant Creator'
+.grid-x
+  .cell.small-12
+    = f.check_box :system_admin
+    = f.label :system_admin, 'System Administator'

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -29,19 +29,15 @@
       .cell.small-12.medium-2
         = f.label :user_type
       .cell.small-12.medium-10
-        - if @user.grant_creator?
-          Grant Creator
-        - elsif @user.system_admin?
-          System Administrator
+        - if current_user.system_admin?
+          = render partial: 'users/admin_checkboxes', locals: { f: f, user: @user } if current_user.system_admin?
         - elsif @user.grant_creator_requests.pending.any?
           .button.holow.disabled
             Pending Grant Creation Request
+        - elsif @user.grant_creator?
+          Grant Creator
         - else
-          User
-          %br
           = link_to 'Request Grant Creation Permission', new_grant_creator_request_path if current_user == @user
-
-
 .actions
   = f.submit 'Update', class: 'button'
 


### PR DESCRIPTION
Adds grant_creator and system_admin checkboxes on user profiles. Accessible to and permitted for system admins only.  Makes granting privileges simpler.

Closes #174 