### PR TITLE
Clean up grant submission section

### DIFF
--- a/app/models/grant_submission/section.rb
+++ b/app/models/grant_submission/section.rb
@@ -13,38 +13,17 @@ module GrantSubmission
                          dependent: :destroy,
                          foreign_key: 'grant_submission_section_id',
                          inverse_of: :section
-    # has_one :condition_group, as: :owner,
-    #                           dependent: :destroy
-    #                           optional: true
-
-    scope :repeatable,     -> { where(repeatable: true) }
-    scope :non_repeatable, -> { where(repeatable: [nil, false]) }
 
     accepts_nested_attributes_for :questions, allow_destroy: true
 
-    validates_presence_of :form, :title #, :display_order
-    # validates_numericality_of :display_order, only_integer: true, greater_than: 0
-    validates_length_of :title, maximum: 255
-
-    def self.human_readable_attribute(attr)
-      {}[attr] || attr.to_s.humanize
-    end
-
-    # def to_export_hash
-    #   {
-    #       title: title,
-    #       display_order: display_order,
-    #       repeatable: repeatable,
-    #       questions_attributes: questions.map(&:to_export_hash)
-    #   }
-    # end
+    validates_presence_of     :form, :title
+    validates_length_of       :title, maximum: 255
+    validates_uniqueness_of   :title, scope: :form
+    validates_uniqueness_of   :display_order, scope: :form
+    validates_numericality_of :display_order, only_integer: true, greater_than: 0, on: :update, if: -> { display_order.present? }
 
     def available?
       new_record? || form.available?
-    end
-
-    def text
-      title
     end
   end
 end

--- a/app/views/grant_submissions/forms/_form_table_row.html.erb
+++ b/app/views/grant_submissions/forms/_form_table_row.html.erb
@@ -1,4 +1,0 @@
-<tr class="<%= attr.to_s %>">
-  <td><%= f.label(attr, f.object.class.human_readable_attribute(attr)) %></td>
-  <td><% field.(attr) %></td>
-</tr>

--- a/app/views/grant_submissions/forms/_section_form.html.erb
+++ b/app/views/grant_submissions/forms/_section_form.html.erb
@@ -1,7 +1,7 @@
 <fieldset class="fieldset form_builder_section_fieldset">
   <legend>
     <span>Section</span>
-    <%= section.link_to_remove 'Delete', { class: 'delete-section button tiny btn-pill alert hollow', title: 'Delete this section and its questions'} if has_edit_permission %>
+    <%= section.link_to_remove "Delete", { id: "delete-section-#{section.object.id}", class: 'delete-section button tiny btn-pill alert hollow', title: 'Delete this section and its questions'} if has_edit_permission %>
   </legend>
 
   <table class="section_table table unstriped">

--- a/config/locales/activerecord/grant_submission_section.yml
+++ b/config/locales/activerecord/grant_submission_section.yml
@@ -1,11 +1,16 @@
 en:
   activerecord:
     attributes:
-      grant_submission:
-        sections:
+      sections:
+        title: Section Title
     errors:
       models:
-        grant_submission/form/sections:
+        grant_submission/section:
+          attributes:
+            title:
+              taken: must be unique to this competition.
+    models:
+      grant_submission/section: Section
   helpers:
     label:
       grant_submission_form:

--- a/db/migrate/20191015145255_remove_repeatable_from_grant_submission_sections.rb
+++ b/db/migrate/20191015145255_remove_repeatable_from_grant_submission_sections.rb
@@ -1,0 +1,5 @@
+class RemoveRepeatableFromGrantSubmissionSections < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :grant_submission_sections, :repeatable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_03_201916) do
+ActiveRecord::Schema.define(version: 2019_10_15_145255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -291,7 +291,6 @@ ActiveRecord::Schema.define(version: 2019_10_03_201916) do
     t.bigint "grant_submission_form_id", null: false
     t.string "title"
     t.integer "display_order", null: false
-    t.boolean "repeatable"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["display_order", "grant_submission_form_id"], name: "i_submission_sections_on_display_order_and_submission_form_id", unique: true

--- a/spec/factories/grant.rb
+++ b/spec/factories/grant.rb
@@ -85,9 +85,9 @@ FactoryBot.define do
         editor = create(:editor_grant_permission, grant: grant)
         viewer = create(:viewer_grant_permission, grant: grant)
 
-        create(:grant_submission_form, grant: grant,
-                                       form_created_by: admin.user,
-                                       form_updated_by: admin.user)
+        create(:grant_submission_form_with_section, grant: grant,
+                                                    form_created_by: admin.user,
+                                                    form_updated_by: admin.user)
       end
     end
 
@@ -113,7 +113,7 @@ FactoryBot.define do
 
     factory :new_grant,                                     traits: %i[new]
     factory :new_grant_with_users,                          traits: %i[new with_users]
-    factory :draft_grant,                                   traits: %i[draft]
+    factory :draft_grant,                                   traits: %i[draft with_users_and_submission_form]
     factory :published_grant,                               traits: %i[published]
     factory :open_grant_with_users,                         traits: %i[published open with_users]
     factory :closed_grant_with_users,                       traits: %i[closed with_users]

--- a/spec/factories/grant_submission_form.rb
+++ b/spec/factories/grant_submission_form.rb
@@ -7,23 +7,26 @@ FactoryBot.define do
     association             :form_updated_by, factory: :user
     submission_instructions { Faker::Lorem.sentence(1) }
 
-    after(:create) do |form|
-      section = create(:grant_submission_section, grant_submission_form_id: form.id)
-      create(:short_text_question, grant_submission_section_id: section.id,
-                                   text: 'Question 1',
-                                   display_order: 1)
-      create(:number_question,     grant_submission_section_id: section.id,
-                                   text: 'Question 2',
-                                   display_order: 2)
-      create(:long_text_question,  grant_submission_section_id: section.id,
-                                   text: 'Question 3',
-                                   display_order: 3)
+    trait :with_section do
+      after(:create) do |form|
+        section = create(:grant_submission_section, grant_submission_form_id: form.id)
+        create(:short_text_question, grant_submission_section_id: section.id,
+                                     text: 'Question 1',
+                                     display_order: 1)
+        create(:number_question,     grant_submission_section_id: section.id,
+                                     text: 'Question 2',
+                                     display_order: 2)
+        create(:long_text_question,  grant_submission_section_id: section.id,
+                                     text: 'Question 3',
+                                     display_order: 3)
+      end
     end
 
     trait :disabled do
       disabled { true }
     end
 
-    factory :disabled_grant_submission_form, traits: %i[disabled]
+    factory :disabled_grant_submission_form,     traits: %i[disabled]
+    factory :grant_submission_form_with_section, traits: %i[with_section]
   end
 end

--- a/spec/factories/grant_submission_section.rb
+++ b/spec/factories/grant_submission_section.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :grant_submission_section, class: 'GrantSubmission::Section' do
-    association :grant_submission_form, factory: :grant_submission_form
-    title           { Faker::Lorem.sentence }
-    display_order   { 1 }
-    repeatable      { false}
+    association :form, factory: :grant_submission_form
+    sequence(:title) { |n| "#{Faker::Lorem.sentence} #{n}" }
+    display_order    { 1 }
+    repeatable       { false}
   end
 end

--- a/spec/factories/grant_submission_section.rb
+++ b/spec/factories/grant_submission_section.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     association :form, factory: :grant_submission_form
     sequence(:title) { |n| "#{Faker::Lorem.sentence} #{n}" }
     display_order    { 1 }
-    repeatable       { false}
   end
 end

--- a/spec/models/grant_submission_section_spec.rb
+++ b/spec/models/grant_submission_section_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe GrantSubmission::Section, type: :model do
+  it { is_expected.to respond_to(:title) }
+  it { is_expected.to respond_to(:display_order) }
+
+  let(:section) { create(:grant_submission_section) }
+
+  describe '#validations' do
+    it 'validates a valid section' do
+      expect(section).to be_valid
+    end
+
+    it 'requires a form' do
+      section.form = nil
+      expect(section).not_to be_valid
+      expect(section.errors).to include(:form)
+    end
+
+    it 'does not allow a title longer than 255 characters' do
+      section.title = Faker::Lorem.characters(256)
+      expect(section).not_to be_valid
+      expect(section.errors).to include(:title)
+      section.title = Faker::Lorem.characters(255)
+      expect(section).to be_valid
+    end
+  end
+
+  describe 'available' do
+    it 'is available? when new' do
+      expect(section.available?).to be true
+    end
+
+    it 'is not available? when parent form is not available' do
+      allow_any_instance_of(GrantSubmission::Form).to receive(:available?).and_return(false)
+      expect(section.available?).to be false
+    end
+  end
+end

--- a/spec/system/grant_reviewers/grant_reviewers_spec.rb
+++ b/spec/system/grant_reviewers/grant_reviewers_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'GrantReviewers', type: :system do
 
     scenario 'reviewer and reveiwer submissions can be deleted' do
       reviewer = @grant.grant_reviewers.first.reviewer
-      expect(reviewer.reviews.by_grant(Grant.last).count).to eq(1)
+      expect(reviewer.reviews.by_grant(@grant).count).to eq(1)
       click_link('Remove', href: grant_reviewer_path(@grant, @grant.grant_reviewers.first))
       page.driver.browser.switch_to.alert.accept
       expect(page).to have_content 'Reviewer and their reviews have been deleted for this grant.'

--- a/spec/system/grant_submissions/grant_submission_forms_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_forms_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'GrantSubmissiion::Forms', type: :system do
         expect(page).to have_text 'Submission Form successfully updated'
       end
 
-      scenario 'display_order is updated' do
+      scenario 'display_order is updated on delete' do
         original_section = @draft_grant.form.sections.first
         expect(original_section.display_order).to be 1
         find('.delete-section').click
@@ -42,6 +42,22 @@ RSpec.describe 'GrantSubmissiion::Forms', type: :system do
         click_button 'Save'
         expect(@draft_grant.form.sections.first.display_order).not_to be 2
         expect(@draft_grant.form.sections.first.display_order).to be 1
+      end
+
+      scenario 'display_order is updated when section in middle of form is deleted' do
+        original_first_section = @draft_grant.form.sections.first
+        click_link add_section_text
+        find_field('Title', with: '').set('Section to be deleted')
+        click_link add_section_text
+        find_field('Title', with: '').set('Section Last')
+        click_button 'Save'
+        original_section_section = @draft_grant.form.sections.second
+        original_last_section    = @draft_grant.form.sections.last
+        page.find("#delete-section-#{original_section_section.id}").click
+        click_button 'Save'
+        expect(@draft_grant.form.sections.count).to be 2
+        expect(GrantSubmission::Section.find(original_first_section.id).display_order).to be 1
+        expect(GrantSubmission::Section.find(original_last_section.id).display_order).to be 2
       end
     end
 

--- a/spec/system/grant_submissions/grant_submission_sections_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_sections_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'GrantSubmission::Sections', type: :system do
+  describe 'Grant Edit section', js: true do
+    before(:each) do
+      @grant = create(:draft_grant)
+      @form  = @grant.form
+
+      login_as(@grant.editors.first)
+      visit edit_grant_form_path(@grant, @form)
+    end
+
+    scenario 'it requires a title' do
+      click_link 'Add a Section'
+      find_field('Title', with: '').set('')
+      click_button 'Save'
+      expect(page).not_to have_text 'Submission Form successfully update'
+      expect(page).to have_text 'Section Title is required.'
+    end
+
+    scenario 'it requires a unique title' do
+      click_link 'Add a Section'
+      find_field('Title', with: '').set(@form.sections.first.title)
+      click_button 'Save'
+      expect(page).not_to have_text 'Submission Form successfully update'
+      expect(page).to have_text 'Section Title must be unique to this competition.'
+    end
+  end
+end


### PR DESCRIPTION
Cleanup FormBuilder remants from GrantSubmission::Section
- remove unused methods, scopes and comments
- migration to remove :repeatable
- update related factories
- update validations, add model specific error text to locales
- add system and model specs


Related to #217 