### PR TITLE
GrantSubmission::Question and MultipleChoiceOption cleanup and specs

### DIFF
--- a/app/models/grant_submission/form.rb
+++ b/app/models/grant_submission/form.rb
@@ -35,7 +35,7 @@ class GrantSubmission::Form < ApplicationRecord
 
   def destroyable?
     false
-    # available? && grant_forms.empty? # && mb_messages.empty? && instructions.empty?
+    # available? && grant_forms.empty? && instructions.empty?
   end
 
   # This method first re-numbers sections/questions/answers from an offset

--- a/app/models/grant_submission/multiple_choice_option.rb
+++ b/app/models/grant_submission/multiple_choice_option.rb
@@ -4,8 +4,6 @@ module GrantSubmission
     has_paper_trail versions: { class_name: 'PaperTrail::GrantSubmission::MultipleChoiceOptionVersion' },
                     meta:     { grant_submission_question_id: :grant_submission_question_id }
 
-    # has_paper_trail ignore: [:display_order]
-
     belongs_to :question,  class_name: 'GrantSubmission::Question',
                            foreign_key: 'grant_submission_question_id',
                            inverse_of: :multiple_choice_options
@@ -13,18 +11,9 @@ module GrantSubmission
                            foreign_key: 'grant_submission_multiple_choice_option_id',
                            inverse_of: :multiple_choice_option
 
-    validates_presence_of :question, :text
+    validates_presence_of   :question, :text
     validates_uniqueness_of :text, scope: :grant_submission_question_id
-    validates_length_of :text, maximum: 255
-
-    def self.human_readable_attribute(attr)
-      {}[attr] || attr.to_s.humanize
-    end
-
-    def to_formatted_s(format = nil)
-      # TODO: was export code dependent
-      text
-    end
+    validates_length_of     :text, maximum: 255
 
     def available?
       new_record? || question.section.form.available?

--- a/app/views/grant_submissions/forms/_answer_form.html.erb
+++ b/app/views/grant_submissions/forms/_answer_form.html.erb
@@ -1,4 +1,3 @@
 <td><%= multiple_choice_option.text_field :text %></td>
 <td><%= multiple_choice_option.text_field :display_order, size: 3 %></td>
-<!-- <td><%#= mulitple_choice_option.text_field :export_code, size: 5 %></td> -->
 <td><%= multiple_choice_option.link_to_remove "Delete", class: "button tiny btn-pill warning" %></td>

--- a/config/locales/activerecord/grant_submission_question.yml
+++ b/config/locales/activerecord/grant_submission_question.yml
@@ -14,6 +14,8 @@ en:
       models:
         grant_submission/question:
           attributes:
+            text:
+              taken: must be unique in its section.
             is_mandatory:
               blank: must be selected.
               inclusion: must be selected.

--- a/spec/factories/grant.rb
+++ b/spec/factories/grant.rb
@@ -124,7 +124,7 @@ FactoryBot.define do
     factory :published_not_yet_open_grant,                  traits: %i[published not_yet_open]
     factory :published_not_yet_open_grant_with_users,       traits: %i[published not_yet_open with_users]
     factory :completed_grant,                               traits: %i[completed closed]
-    factory :draft_open_grant,                              traits: %i[draft open]
+    factory :draft_open_grant,                              traits: %i[draft open with_users_and_submission_form]
     factory :draft_closed_grant,                            traits: %i[draft closed]
     factory :grant_with_users,                              traits: %i[published with_users_and_submission_form]
     factory :demo_grant_with_users,                         traits: %i[demo with_users]

--- a/spec/factories/grant_submission_question.rb
+++ b/spec/factories/grant_submission_question.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :grant_submission_question, class: 'GrantSubmission::Question' do
-    association   :grant_submission_section, factory: :grant_submission_section
+    association   :section, factory: :grant_submission_section
     text          { Faker::Lorem.question }
     instruction   { Faker::Lorem.sentence }
     display_order { 1 }
@@ -29,10 +29,24 @@ FactoryBot.define do
       response_type { 'date_opt_time' }
     end
 
-    factory :short_text_question, traits: %i[short_text]
-    factory :long_text_question,  traits: %i[long_text]
-    factory :number_question,     traits: %i[number]
-    factory :date_question,       traits: %i[date]
+    trait :multiple_choice_option do
+      response_type { 'pick_one' }
+    end
+
+    trait :with_options do
+      before(:create) do |question|
+        2.times do |i|
+          question.multiple_choice_options << build(:multiple_choice_option, display_order: (i+1))
+        end
+      end
+    end
+
+    factory :short_text_question,                   traits: %i[short_text]
+    factory :long_text_question,                    traits: %i[long_text]
+    factory :number_question,                       traits: %i[number]
+    factory :date_question,                         traits: %i[date]
+    factory :multiple_choice_question,              traits: %i[multiple_choice_option]
+    factory :multiple_choice_question_with_options, traits: %i[multiple_choice_option with_options]
   end
 end
 

--- a/spec/factories/multiple_choice_option.rb
+++ b/spec/factories/multiple_choice_option.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :multiple_choice_option, class: 'GrantSubmission::MultipleChoiceOption' do
+    association     :question, factory: :grant_submission_question
+    sequence(:text) { |n| "Option #{n}" }
+    display_order   { 1 }
+  end
+end

--- a/spec/models/grant_submission_form_spec.rb
+++ b/spec/models/grant_submission_form_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe GrantSubmission::Form, type: :model do
       expect(form.errors).not_to include(:submission_instructions)
     end
   end
+
+  describe '#methods' do
+    it 'is not destroyable?' do
+      expect(form.destroyable?).to be false
+    end
+  end
 end

--- a/spec/models/grant_submission_multiple_choice_option_spec.rb
+++ b/spec/models/grant_submission_multiple_choice_option_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe GrantSubmission::MultipleChoiceOption, type: :model do
+  it { is_expected.to respond_to(:question) }
+  it { is_expected.to respond_to(:text) }
+
+  let(:multiple_choice_option) { create(:multiple_choice_option) }
+
+  describe '#validations' do
+    it 'validates a valid multiple choice option' do
+      expect(multiple_choice_option).to be_valid
+    end
+
+    it 'requires a question' do
+      multiple_choice_option.question = nil
+      expect(multiple_choice_option).not_to be_valid
+      expect(multiple_choice_option.errors).to include(:question)
+    end
+
+    it 'requires text' do
+      multiple_choice_option.text = nil
+      expect(multiple_choice_option).not_to be_valid
+      expect(multiple_choice_option.errors).to include(:text)
+    end
+
+    it 'requires text to be less than 255 characters' do
+      multiple_choice_option.text = Faker::Lorem.characters(256)
+      expect(multiple_choice_option).not_to be_valid
+      expect(multiple_choice_option.errors).to include(:text)
+      multiple_choice_option.text = Faker::Lorem.characters(255)
+      expect(multiple_choice_option).to be_valid
+    end
+  end
+
+  describe '#available?' do
+    it 'is available? when new' do
+      expect(multiple_choice_option.available?).to be true
+    end
+
+    it 'is not available? when parent form is not available' do
+      allow_any_instance_of(GrantSubmission::Form).to receive(:available?).and_return(false)
+      expect(multiple_choice_option.available?).to be false
+    end
+  end
+end

--- a/spec/models/grant_submission_question_spec.rb
+++ b/spec/models/grant_submission_question_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe GrantSubmission::Question, type: :model do
+  it { is_expected.to respond_to(:section) }
+  it { is_expected.to respond_to(:form) }
+  it { is_expected.to respond_to(:text) }
+  it { is_expected.to respond_to(:display_order) }
+  it { is_expected.to respond_to(:is_mandatory) }
+  it { is_expected.to respond_to(:instruction) }
+
+  context 'short_answer question' do
+    describe '#validations' do
+      let(:question) { build(:grant_submission_question) }
+
+      it 'validates a valid question' do
+        expect(question).to be_valid
+      end
+
+      it 'requires a section' do
+        question.section = nil
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:section)
+      end
+
+      it 'requires a response_type' do
+        question.section = nil
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:section)
+      end
+
+      it 'requires a positive display_order' do
+        question.display_order = -1
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:display_order)
+      end
+
+      it 'requires response_type to be a valid response type' do
+        question.response_type = Faker::Lorem.word
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:response_type)
+      end
+
+      it 'requires instruction to be 4000 characters or less' do
+        question.instruction = Faker::Lorem.characters(4001)
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:instruction)
+        question.instruction = Faker::Lorem.characters(4000)
+        expect(question).to be_valid
+      end
+
+      it 'requires text' do
+        question.text = ''
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:text)
+      end
+
+      it 'requires text to be 4000 characters or less' do
+        question.text = Faker::Lorem.characters(4001)
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:text)
+        question.text = Faker::Lorem.characters(4000)
+        expect(question).to be_valid
+      end
+
+      it 'requires is_mandatory to be boolean value' do
+        question.is_mandatory = nil
+        expect(question).not_to be_valid
+        expect(question.errors).to include(:is_mandatory)
+      end
+    end
+  end
+
+  context 'long_text question' do
+    describe '#validations' do
+      let(:question) { build(:long_text_question) }
+
+      it 'validates a valid question' do
+        expect(question).to be_valid
+      end
+    end
+  end
+
+  context 'number question' do
+    describe '#validations' do
+      let(:question) { build(:number_question) }
+
+      it 'validates a valid question' do
+        expect(question).to be_valid
+      end
+    end
+  end
+
+  context 'date question' do
+    describe '#validations' do
+      let(:question) { build(:date_question) }
+
+      it 'validates a valid question' do
+        expect(question).to be_valid
+      end
+    end
+  end
+
+  context 'multiple_choice_question' do
+    describe '#validations' do
+      let(:multiple_choice_question) { create(:multiple_choice_question_with_options) }
+
+      it 'validates a valid question' do
+        expect(multiple_choice_question).to be_valid
+      end
+
+      it 'requires at least one option' do
+        multiple_choice_question.multiple_choice_options.delete_all
+        expect(multiple_choice_question).not_to be_valid
+        expect(multiple_choice_question.errors.messages[:response_type].to_s).to include('requires at least one option')
+      end
+    end
+  end
+
+  context 'available' do
+    let(:question)  { build(:grant_submission_question) }
+
+    it 'is not available if form is not available' do
+      allow_any_instance_of(GrantSubmission::Form).to receive(:available?).and_return(false)
+      expect(question.available?).to be true
+    end
+
+    it 'is available if form is available' do
+      allow_any_instance_of(GrantSubmission::Form).to receive(:available?).and_return(true)
+      expect(question.available?).to be true
+    end
+  end
+end

--- a/spec/system/grant_submissions/grant_submission_forms_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_forms_spec.rb
@@ -62,27 +62,6 @@ RSpec.describe 'GrantSubmission::Forms', type: :system do
     end
 
     context 'question' do
-      scenario 'cannot be added when invalid' do
-        expect do
-          click_link add_question_text
-          click_button 'Save'
-        end.not_to (change{@draft_grant.questions.count})
-
-        expect(page).to have_text 'Question Text is required'
-        expect(page).to have_text 'Question Response Type must be selected'
-      end
-
-      scenario 'can be added to an existing section' do
-        expect do
-          new_question_text = Faker::Lorem.sentence
-          click_link add_question_text
-          find_field('Question Text', with: '').set(new_question_text)
-          find_field('Type of Response', with: '').select('Number')
-          click_button 'Save'
-        end.to (change{@draft_grant.questions.count}).by 1
-        expect(page).to have_text 'Submission Form successfully updated'
-      end
-
       scenario 'display_order is updated on delete' do
         page.find("#delete-question-#{@original_first_question.id}").click
         click_button 'Save'

--- a/spec/system/grant_submissions/grant_submission_questions_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_questions_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'GrantSubmission::Questions', type: :system do
+  add_question_text = 'Add a Question to this Section'
+  add_section_text  = 'Add a Section'
+
+  describe 'Grant Edit question', js: true do
+    before(:each) do
+      @grant = create(:draft_open_grant)
+      @form  = @grant.form
+
+      login_as(@grant.editors.first)
+      visit edit_grant_form_path(@grant, @form)
+    end
+
+    scenario 'cannot be added when invalid' do
+      expect do
+        click_link add_question_text
+        click_button 'Save'
+      end.not_to (change{@grant.questions.count})
+
+      expect(page).to have_text 'Question Text is required'
+      expect(page).to have_text 'Question Response Type must be selected'
+    end
+
+    scenario 'can be added to an existing section' do
+      expect do
+        new_question_text = Faker::Lorem.sentence
+        click_link add_question_text
+        find_field('Question Text', with: '').set(new_question_text)
+        find_field('Type of Response', with: '').select('Number')
+        click_button 'Save'
+      end.to (change{@grant.questions.count}).by 1
+      expect(page).to have_text 'Submission Form successfully updated'
+    end
+
+    scenario 'it requires questions in a section to have unique text' do
+      find_field('Question Text', with: "#{@grant.questions.second.text}").set("#{@grant.questions.first.text}")
+      click_button 'Save'
+      expect(page).not_to have_text 'Submission Form successfully updated'
+      expect(page).to have_text I18n.t('activerecord.errors.models..grant_submission/question.attributes.text.taken')
+    end
+
+    scenario 'it allows duplicate question text between sections' do
+      click_link add_section_text
+      find_field('Title', with: '').set('New Section')
+      within all("fieldset").last do
+        click_link(add_question_text)
+        find_field('Question Text', with: '').set(@grant.questions.first.text)
+        find_field('Type of Response').select('Number')
+      end
+      click_button 'Save'
+      expect(page).to have_text 'Submission Form successfully updated'
+    end
+  end
+end


### PR DESCRIPTION
Adds specs and removes unused methods in GrantSubmissIon::Question and GrantSubmission::MultipleChoiceOption. Some of specs may be overkill and others may be undercooked, but helps to set up the ::Submission and ::Response cleanup.