### PR TITLE
Add join and access dates to users page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
   def index
     authorize User, :index?
     @q = User.all.ransack(params[:q])
-    @q.sorts = 'last_name asc' if @q.sorts.empty?
+    @q.sorts = 'current_sign_in_at desc' if @q.sorts.empty?
     @pagy, @users = pagy(@q.result, i18n_key: 'activerecord.models.user')
   end
 

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,0 +1,6 @@
+%tr{id: "user-#{user.id}", class: 'user'}
+  %td= link_to sortable_full_name(user), edit_user_path(user)
+  %td= user.email
+  %td= date_mmddyyyy(user.created_at)
+  %td= time_ago_in_words(user.current_sign_in_at)
+  %td= link_to 'Edit', edit_user_path(user)

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -14,10 +14,12 @@
       = f.submit 'Search', class: 'button'
       = link_to 'Reset', users_path, class: 'button clear secondary'
 
-- if @users.empty?
+- unless @users.present?
   %p
     No users were found.
+
 - else
+
   = render partial: 'shared/pagy_header', locals: { pagy: @pagy }
 
   %table
@@ -27,11 +29,12 @@
           = sort_link(@q, :last_name, 'Name')
         %th
           = sort_link(@q, :email)
+        %th
+          = sort_link(@q, :created_at, 'Joined')
+        %th
+          = sort_link(@q, :current_sign_in_at, 'Last Access')
+        %th
 
-    %tbody
-      - @users.each do |user|
-        %tr
-          %td= link_to sortable_full_name(user), edit_user_path(user)
-          %td= user.email
+    = render @users
 
   != pagy_foundation_nav(@pagy)

--- a/spec/system/grants/grants_spec.rb
+++ b/spec/system/grants/grants_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe 'Grants', type: :system do
     end
 
     context 'anoymous user' do
-      scenario 'can view publisehed open grant' do
+      scenario 'can view published open grant' do
         visit grant_path(@grant)
         expect(page).not_to have_content authorization_error_text
         expect(page).to have_link 'Apply Now'

--- a/spec/system/users/users_spec.rb
+++ b/spec/system/users/users_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+include UsersHelper
+
+RSpec.describe 'Users', type: :system do
+  def authorization_error_text
+    I18n.t('pundit.default')
+  end
+
+  describe 'Index', js: true do
+    before(:each) do
+      @user1         = create(:user, last_name: 'BBBB',
+                                     created_at: 65.minutes.ago,
+                                     current_sign_in_at: 65.minutes.ago)
+      @user2         = create(:user, last_name: 'AAAA',
+                                     created_at: 1.month.ago,
+                                     current_sign_in_at: 1.day.ago)
+      @grant_creator = create(:grant_creator_user, last_name: 'ZZZZ',
+                                                   created_at: 1.week.ago,
+                                                   current_sign_in_at: 1.month.ago)
+      @system_admin  = create(:system_admin_user, last_name: 'CCCC',
+                                                  created_at: 1.year.ago)
+    end
+
+    describe 'Index' do
+      context 'Policy' do
+        scenario 'disallows anonymous user access' do
+          visit users_path
+
+          expect(page).not_to have_current_path(users_path) # redirects to login
+        end
+
+        scenario 'disallows user access' do
+          login_as(@user1)
+          visit users_path
+
+          expect(page).to have_current_path(root_path)
+          expect(page).to have_text authorization_error_text
+        end
+
+        scenario 'disallows grant_creator user access' do
+          login_as(@grant_creator)
+          visit users_path
+
+          expect(page).to have_current_path(root_path)
+          expect(page).to have_text authorization_error_text
+        end
+
+        scenario 'allows system_admin user access' do
+          login_as(@system_admin)
+          visit users_path
+
+          expect(page).not_to have_text authorization_error_text
+          expect(page).to have_text 'All Users'
+        end
+      end
+
+      context 'Sorts' do
+        before(:each) do
+          login_as @system_admin
+          visit users_path
+          @system_admin.update_attribute(:current_sign_in_at, 45.days.ago)
+          @system_admin.save!
+        end
+
+        scenario 'default sort by current_sign_in_at' do
+          visit users_path
+          within 'tr.user:nth-child(1)' do
+            expect(page).to have_text "#{sortable_full_name(@user1)} #{@user1.email}"
+          end
+          within 'tr.user:nth-child(2)' do
+            expect(page).to have_text "#{sortable_full_name(@user2)} #{@user2.email}"
+          end
+          within 'tr.user:nth-child(3)' do
+            expect(page).to have_text "#{sortable_full_name(@grant_creator)} #{@grant_creator.email}"
+          end
+          within 'tr.user:nth-child(4)' do
+            expect(page).to have_text "#{sortable_full_name(@system_admin)} #{@system_admin.email}"
+          end
+        end
+
+        scenario 'reverse sort by current_sign_in_at' do
+          visit users_path
+          click_on('Last Access')
+          within 'tr.user:nth-child(4)' do
+            expect(page).to have_text "#{sortable_full_name(@user1)} #{@user1.email}"
+          end
+          within 'tr.user:nth-child(3)' do
+            expect(page).to have_text "#{sortable_full_name(@user2)} #{@user2.email}"
+          end
+          within 'tr.user:nth-child(2)' do
+            expect(page).to have_text "#{sortable_full_name(@grant_creator)} #{@grant_creator.email}"
+          end
+          within 'tr.user:nth-child(1)' do
+            expect(page).to have_text "#{sortable_full_name(@system_admin)} #{@system_admin.email}"
+          end
+        end
+
+        scenario 'sort by created_at' do
+          @user1.update_attribute(:created_at, 3.weeks.ago)
+          @user2.update_attribute(:created_at, 1.day.ago)
+          @grant_creator.update_attribute(:created_at, 1.year.ago)
+          @system_admin.update_attribute(:created_at, 181.days.ago)
+
+          visit users_path
+          click_on('Joined')
+          within 'tr.user:nth-child(4)' do
+            expect(page).to have_text "#{sortable_full_name(@user2)} #{@user2.email}"
+          end
+          within 'tr.user:nth-child(3)' do
+            expect(page).to have_text "#{sortable_full_name(@user1)} #{@user1.email}"
+          end
+          within 'tr.user:nth-child(2)' do
+            expect(page).to have_text "#{sortable_full_name(@system_admin)} #{@system_admin.email}"
+          end
+          within 'tr.user:nth-child(1)' do
+            expect(page).to have_text "#{sortable_full_name(@grant_creator)} #{@grant_creator.email}"
+          end
+
+          click_on('Joined')
+          within 'tr.user:nth-child(1)' do
+            expect(page).to have_text "#{sortable_full_name(@user2)} #{@user2.email}"
+          end
+          within 'tr.user:nth-child(2)' do
+            expect(page).to have_text "#{sortable_full_name(@user1)} #{@user1.email}"
+          end
+          within 'tr.user:nth-child(3)' do
+            expect(page).to have_text "#{sortable_full_name(@system_admin)} #{@system_admin.email}"
+          end
+          within 'tr.user:nth-child(4)' do
+            expect(page).to have_text "#{sortable_full_name(@grant_creator)} #{@grant_creator.email}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses Devise's trackable attributes. Specs may be a bit of overkill. Let me know if you think they can be deleted.

Closes #215 