### PR TITLE
Add ReviewerMailer specs #276

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,11 +2,11 @@
 
 module UsersHelper
   def full_name(user)
-    [user.first_name.titleize, user.last_name.titleize].reject { |n| n.nil? or n.blank? }.join(' ')
+    [user.first_name, user.last_name].reject { |n| n.nil? or n.blank? }.join(' ')
   end
 
   def sortable_full_name(user)
-    [user.last_name.titleize, user.first_name.titleize].reject { |n| n.nil? or n.blank? }.join(', ')
+    [user.last_name, user.first_name].reject { |n| n.nil? or n.blank? }.join(', ')
   end
 
 end

--- a/app/mailers/reviewer_mailer.rb
+++ b/app/mailers/reviewer_mailer.rb
@@ -1,29 +1,32 @@
 class ReviewerMailer < ApplicationMailer
-  before_action :set_attributes
+  def assignment(review:)
+    set_attributes(review)
 
-  def assignment
     mail(to: @reviewer.email, subject: I18n.t('mailers.reviewer_mailer.assignment.subject'))
   end
 
-  def unassignment
+  def unassignment(review:)
+    set_attributes(review)
+
     mail(to: @reviewer.email, subject: I18n.t('mailers.reviewer_mailer.unassignment.subject'))
   end
 
-  def opt_out
-    @recipient_emails = define_opt_out_recipients
-    mail(to:@recipient_emails, subject: I18n.t('mailers.reviewer_mailer.opt_out.subject'))
+  def opt_out(review:)
+    set_attributes(review)
+
+    mail(to: get_opt_out_recipients, subject: I18n.t('mailers.reviewer_mailer.opt_out.subject'))
   end
 
   private
 
-  def set_attributes
-    @review     = params[:review]
+  def set_attributes(review)
+    @review     = review
     @reviewer   = @review.reviewer
     @submission = @review.submission
     @grant      = @review.grant
   end
 
-  def define_opt_out_recipients
+  def get_opt_out_recipients
     if @review.assigner.editable_grants.include?(@grant)
       @review.assigner.email
     else

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,7 +1,7 @@
 class Review < ApplicationRecord
   include WithScoring
   has_paper_trail versions: { class_name: 'PaperTrail::ReviewVersion' },
-                  meta:     { grant_id: :get_grant_id, reviewer_id: :reviewer_id }
+                  meta:     { grant_id: proc { |review| review.grant.id }, reviewer_id: :reviewer_id }
 
   belongs_to :assigner,       class_name: 'User',
                               foreign_key: 'assigner_id'
@@ -64,10 +64,6 @@ class Review < ApplicationRecord
   end
 
   private
-
-  def get_grant_id
-    grant.id
-  end
 
   def reviewer_is_a_grant_reviewer
     errors.add(:reviewer, :is_not_a_reviewer) unless grant.reviewers.include?(reviewer)

--- a/spec/factories/review.rb
+++ b/spec/factories/review.rb
@@ -7,8 +7,11 @@ FactoryBot.define do
     association :submission, factory: :grant_submission_submission
     association :assigner,   factory: :user
     association :reviewer,   factory: :user
-    overall_impact_score   {}
-    overall_impact_comment {}
+
+    trait :incomplete do
+      overall_impact_score   {}
+      overall_impact_comment {}
+    end
 
     trait :with_score do
       overall_impact_score { rand(Review::MINIMUM_ALLOWED_SCORE..Review::MAXIMUM_ALLOWED_SCORE) }
@@ -26,6 +29,7 @@ FactoryBot.define do
       end
     end
 
+    factory :incomplete_review,                                   traits: %i[incomplete]
     factory :review_with_score,                                   traits: %i[with_score]
     factory :review_with_comment,                                 traits: %i[with_comment]
     factory :review_with_score_and_comment,                       traits: %i[with_score with_comment]

--- a/spec/mailers/grant_creator_request_review_mailer_spec.rb
+++ b/spec/mailers/grant_creator_request_review_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GrantCreatorRequestReviewMailer, type: :mailer do
 
     it 'addresses the requester by their full name' do
       requester = approved_request.requester
-      expect(mailer.body).to include "Dear #{requester.first_name} #{requester.last_name}"
+      expect(mailer.body.encoded).to include "Dear #{requester.first_name} #{CGI.escapeHTML(requester.last_name)}"
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe GrantCreatorRequestReviewMailer, type: :mailer do
 
     it 'addressed the requester by their full name' do
       requester = rejected_request.requester
-      expect(mailer.body).to include "Dear #{requester.first_name} #{requester.last_name}"
+      expect(mailer.body.encoded).to include "Dear #{requester.first_name} #{CGI.escapeHTML(requester.last_name)}"
     end
   end
 

--- a/spec/mailers/reviewer_mailer_spec.rb
+++ b/spec/mailers/reviewer_mailer_spec.rb
@@ -1,5 +1,95 @@
-require "rails_helper"
+require 'rails_helper'
+include UsersHelper
 
 RSpec.describe ReviewerMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'assignment' do
+    let(:grant)    { create(:open_grant_with_users_and_form_and_submission_and_reviewer) }
+    let(:review)   { create(:incomplete_review, assigner: grant.editors.first,
+                                                reviewer: grant.reviewers.first,
+                                                submission: grant.submissions.first) }
+    let(:reviewer) { review.reviewer }
+    let(:mailer)   { described_class.assignment(review: review) }
+
+    it 'uses the reviewer\'s email address' do
+      expect(mailer.to).to eql [reviewer.email]
+    end
+
+    it 'addresses the reviewer by their full name' do
+      expect(mailer.body.encoded).to include "Dear #{reviewer.first_name} #{CGI.escapeHTML(reviewer.last_name)}"
+    end
+
+    it 'includes a link to the submission page' do
+      expect(mailer.body.encoded).to have_link review.submission.title, href: grant_submission_url(grant, review.submission)
+    end
+
+    it 'includes a link to the grant page' do
+      expect(mailer.body.encoded).to have_link grant.name, href: grant_url(grant)
+    end
+  end
+
+  context 'unassignment' do
+    let(:grant)    { create(:open_grant_with_users_and_form_and_submission_and_reviewer) }
+    let(:review)   { create(:incomplete_review, assigner: grant.editors.first,
+                                                reviewer: grant.reviewers.first,
+                                                submission: grant.submissions.first) }
+    let(:reviewer) { review.reviewer }
+    let(:mailer)   { described_class.unassignment(review: review) }
+
+    it 'uses the reviewer\'s email address' do
+      expect(mailer.to).to eql [reviewer.email]
+    end
+
+    it 'addresses the reviewer by their full name' do
+      expect(mailer.body.encoded).to include "Dear #{reviewer.first_name} #{reviewer.last_name}"
+    end
+
+    it 'includes a link to the grants page' do
+      expect(mailer.body.encoded).to have_link grant.name, href: grant_url(grant)
+    end
+  end
+
+  context 'opt_out' do
+    let(:grant)    { create(:open_grant_with_users_and_form_and_submission_and_reviewer) }
+    let(:review)   { create(:incomplete_review, assigner: grant.editors.second,
+                                                reviewer: grant.reviewers.first,
+                                                submission: grant.submissions.first) }
+    let(:reviewer) { review.reviewer }
+
+    it 'uses the assigner\'s email address' do
+      @mailer = described_class.opt_out(review: review)
+      expect(@mailer.to).to eql [review.assigner.email]
+    end
+
+    it 'uses the only grant administrator\'s when the assigner has no grant permission' do
+      GrantPermission.find_by(user_id: review.assigner.id).destroy
+      @grant_admin = User.find_by(id: grant.grant_permissions.where(role: 'admin').pluck(:user_id))
+
+      @mailer = described_class.opt_out(review: review)
+      expect(@mailer.to).to eql [@grant_admin.email]
+    end
+
+    it 'uses all grant administrators emails when the assigner has no grant permission' do
+      GrantPermission.find_by(user_id: review.assigner.id).destroy
+      GrantPermission.where(grant_id: grant.id).update_all(role: 'admin')
+
+      @grant_admin = User.find_by(id: grant.grant_permissions.where(role: 'admin').pluck(:user_id))
+      @mailer = described_class.opt_out(review: review)
+      expect(@mailer.to).to eql grant.editors.pluck(:email)
+    end
+
+    it 'includes the reviewer name in the body' do
+      @mailer = described_class.opt_out(review: review)
+      expect(@mailer.body.encoded).to include "#{reviewer.first_name} #{CGI.escapeHTML(reviewer.last_name)}"
+    end
+
+    it 'includes a link to the grant in the body' do
+      @mailer = described_class.opt_out(review: review)
+      expect(@mailer.body.encoded).to have_link grant.name, href: grant_url(grant)
+    end
+
+    it 'includes a link to the grant reviewer page in the body' do
+      @mailer = described_class.opt_out(review: review)
+      expect(@mailer.body.encoded).to have_link href: grant_reviewers_url(grant)
+    end
+  end
 end

--- a/spec/models/paper_trail/review_version_spec.rb
+++ b/spec/models/paper_trail/review_version_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe PaperTrail::ReviewVersion, type: :model do
+  before(:each) do
+    @grant          = create(:open_grant_with_users_and_form_and_submission_and_reviewer)
+    @reviewer       = @grant.reviewers.first
+    @review         = create(:review, submission: @grant.submissions.first,
+                                      assigner:   @grant.editors.first,
+                                      reviewer:   @reviewer)
+  end
+
+  describe 'review' do
+    context 'metadata' do
+      it 'tracks grant_id', versioning: true do
+        expect(PaperTrail::ReviewVersion.last.grant_id).to eql @grant.id
+      end
+
+      it 'tracks reviewer_id', versioning: true do
+        expect(PaperTrail::ReviewVersion.last.reviewer_id).to eql @reviewer.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add ReviewerMailer specs
- Add PaperTrail::ReviewVersions spec 
- Add incomplete_review factory
- Use CGI.escapeHTML in mailer specs to account for apostrophes in last names
- Remove .titleize from User *_full_name methods to remove spaces on last names with prefixes
