### PR TITLE
Additional specs per response_type

### DIFF
--- a/config/locales/activerecord/grant_submission_response.yml
+++ b/config/locales/activerecord/grant_submission_response.yml
@@ -24,5 +24,7 @@ en:
             grant_submission_multiple_choice_option_id:
               blank: for '%{question}' is required.
             datetime_val_date_optional_time_magik:
-            string_val:
-              string_too_long: to '%{question}' must be 255 characters or shorter.'
+            short_text:
+              too_long: to '%{question}' must be 255 characters or shorter.'
+            long_text:
+              too_long: to '%{question}' must be %{length} characters or shorter.'

--- a/spec/factories/grant_submission_form.rb
+++ b/spec/factories/grant_submission_form.rb
@@ -11,21 +11,24 @@ FactoryBot.define do
       after(:create) do |form|
         section = create(:grant_submission_section, form: form)
 
-        create(:short_text_question, section: section,
-                                     text: 'Short Text Question',
-                                     display_order: 1)
-        create(:number_question,     section: section,
-                                     text: 'Number Question',
-                                     display_order: 2)
-        create(:long_text_question,  section: section,
-                                     text: 'Long Text Question',
-                                     display_order: 3)
-        create(:multiple_choice_question_with_options, section: section,
-                                     text: 'Multiple Choice Question',
-                                     display_order: 4)
+        create(:short_text_question,  section: section,
+                                      text: 'Short Text Question',
+                                      display_order: 1)
+        create(:number_question,      section: section,
+                                      text: 'Number Question',
+                                      display_order: 2)
+        create(:long_text_question,   section: section,
+                                      text: 'Long Text Question',
+                                      display_order: 3)
+        create(:pick_one_question_with_options, section: section,
+                                      text: 'Multiple Choice Question',
+                                      display_order: 4)
         create(:file_upload_question, section: section,
-                                     text: 'File Upload Question',
-                                     display_order: 5)
+                                      text: 'File Upload Question',
+                                      display_order: 5)
+        create(:date_question,        section: section,
+                                      text: 'Date Question',
+                                      display_order: 6)
       end
     end
 

--- a/spec/factories/grant_submission_question.rb
+++ b/spec/factories/grant_submission_question.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
       response_type { 'date_opt_time' }
     end
 
-    trait :multiple_choice_option do
+    trait :pick_one do
       response_type { 'pick_one' }
     end
 
@@ -38,21 +38,21 @@ FactoryBot.define do
     end
 
     trait :with_options do
-      before(:create) do |question|
+      after(:build) do |question|
         2.times do |i|
           question.multiple_choice_options << build(:multiple_choice_option, question: question, display_order: (i+1))
         end
       end
     end
 
-    factory :short_text_question,                   traits: %i[short_text]
-    factory :required_short_text_question,          traits: %i[short_text required]
-    factory :long_text_question,                    traits: %i[long_text]
-    factory :number_question,                       traits: %i[number]
-    factory :date_question,                         traits: %i[date]
-    factory :multiple_choice_question,              traits: %i[multiple_choice_option]
-    factory :multiple_choice_question_with_options, traits: %i[multiple_choice_option with_options]
-    factory :file_upload_question,                  traits: %i[file_upload]
+    factory :short_text_question,            traits: %i[short_text]
+    factory :required_short_text_question,   traits: %i[short_text required]
+    factory :long_text_question,             traits: %i[long_text]
+    factory :number_question,                traits: %i[number]
+    factory :date_question,                  traits: %i[date]
+    factory :pick_one_question,              traits: %i[pick_one]
+    factory :pick_one_question_with_options, traits: %i[pick_one with_options]
+    factory :file_upload_question,           traits: %i[file_upload]
   end
 end
 

--- a/spec/factories/grant_submission_response.rb
+++ b/spec/factories/grant_submission_response.rb
@@ -13,13 +13,22 @@ FactoryBot.define do
     end
 
     trait :text_val do
-      association :question,   factory: :long_text_question
+      association :question, factory: :long_text_question
       text_val { Faker::Lorem.paragraphs }
     end
 
     trait :number do
       association :question, factory: :number_question
-      decimal_val { Faker::Lorem.number(digits: 5) }
+      decimal_val { Faker::Number.decimal(l_digits: 5, r_digits: 2) }
+    end
+
+    trait :datetime do
+      association :question, factory: :date_question
+      datetime_val { DateTime.now.to_s }
+    end
+
+    trait :pick_one do
+      association :question, factory: :pick_one_question
     end
 
     trait :with_pdf do
@@ -37,5 +46,7 @@ FactoryBot.define do
     factory :number_response,              traits: %i[number]
     factory :valid_file_upload_response,   traits: %i[with_pdf]
     factory :invalid_file_upload_response, traits: %i[with_invalid_file]
+    factory :pick_one_response,            traits: %i[pick_one]
+    factory :date_opt_time_response,       traits: %i[datetime]
   end
 end

--- a/spec/models/grant_submission_question_spec.rb
+++ b/spec/models/grant_submission_question_spec.rb
@@ -102,16 +102,16 @@ RSpec.describe GrantSubmission::Question, type: :model do
 
   context 'pick_one question' do
     describe '#validations' do
-      let(:multiple_choice_question) { create(:multiple_choice_question_with_options) }
+      let(:pick_one_question) { create(:pick_one_question_with_options) }
 
       it 'validates a valid question' do
-        expect(multiple_choice_question).to be_valid
+        expect(pick_one_question).to be_valid
       end
 
       it 'requires at least one option' do
-        multiple_choice_question.multiple_choice_options.delete_all
-        expect(multiple_choice_question).not_to be_valid
-        expect(multiple_choice_question.errors.messages[:response_type].to_s).to include('requires at least one option')
+        pick_one_question.multiple_choice_options.delete_all
+        expect(pick_one_question).not_to be_valid
+        expect(pick_one_question.errors.messages[:response_type].to_s).to include('requires at least one option')
       end
     end
   end

--- a/spec/models/grant_submission_response_spec.rb
+++ b/spec/models/grant_submission_response_spec.rb
@@ -12,69 +12,277 @@ RSpec.describe GrantSubmission::Response, type: :model do
   it { is_expected.to respond_to(:boolean_val) }
   it { is_expected.to respond_to(:document) }
 
-  describe '#validations' do
-    let(:grant)       { create(:published_open_grant_with_users)}
-    let(:other_grant) { create(:published_open_grant_with_users)}
-    let(:submission)  { create(:grant_submission_submission, grant: grant, form: grant.form)}
+  let(:grant)       { create(:published_open_grant_with_users)}
+  let(:other_grant) { create(:open_grant_with_users_and_form_and_submission_and_reviewer)}
+  let(:submission)  { create(:grant_submission_submission, grant: grant, form: grant.form)}
 
-    context 'string_val' do
-      let(:response)    { create(:string_val_response, submission: submission,
-                                                       question:   grant.form.questions.where(response_type: 'short_text').first)}
+  context 'string_val' do
+    let(:string_val_response) { create(:string_val_response, submission: submission,
+                                                             question:   grant.form.questions.where(response_type: 'short_text').first)}
 
-      context '#validations' do
-        it 'validates response to a question from the grant' do
-          expect(response).to be_valid
-        end
+    context '#validations' do
+      it 'validates response to a question from the grant' do
+        expect(string_val_response).to be_valid
+      end
 
-        it 'validates if response is to a question from another grant' do
-          response.update_attribute(:grant_submission_question_id, other_grant.form.questions.where(response_type: 'short_text').first.id)
-          expect(response).not_to be_valid
-          expect(response.errors).to include(:grant_submission_question_id)
-        end
+      it 'requires response when question is_mandatory' do
+        string_val_response.question.update_attribute(:is_mandatory, true)
+        string_val_response.update_attribute(:string_val, '')
+        expect(string_val_response).not_to be_valid
+        expect(string_val_response.errors).to include(:string_val)
+      end
 
-        it 'validates length' do
-          response.update_attribute(:string_val, Faker::Lorem.characters(number: 256))
-          expect(response).not_to be_valid
-          expect(response.errors).to include(:string_val)
-        end
+      it 'requires response to be to a question from its grant' do
+        string_val_response.update_attribute(:grant_submission_question_id, other_grant.form.questions.where(response_type: 'short_text').first.id)
+        expect(string_val_response).not_to be_valid
+        expect(string_val_response.errors).to include(:grant_submission_question_id)
+      end
 
-        it 'validates if attachment' do
-          response.document.attach(io: File.open(Rails.root.join('spec', 'support', 'file_upload', 'text_file.pdf')), filename: 'text_file.pdf')
-          expect(response).not_to be_valid
-          expect(response.errors).to include(:document)
-        end
+      it 'validates length' do
+        string_val_response.update_attribute(:string_val, Faker::Lorem.characters(number: 256))
+        expect(string_val_response).not_to be_valid
+        expect(string_val_response.errors).to include(:string_val)
+      end
+
+      it 'does not allow an attachment' do
+        string_val_response.document.attach(io: File.open(Rails.root.join('spec', 'support', 'file_upload', 'text_file.pdf')), filename: 'text_file.pdf')
+        expect(string_val_response).not_to be_valid
+        expect(string_val_response.errors).to include(:document)
       end
     end
 
-    context 'file_upload' do
-      let(:grant)                { create(:open_grant_with_users_and_form_and_submission_and_reviewer)}
-      let(:file_upload_question) { create(:file_upload_question, section: grant.form.sections.first,
-                                                                 display_order: grant.form.questions.pluck(:display_order).max + 1) }
+    context '#methods' do
+      context 'response_value' do
+        it 'reutrns the string_val text' do
+          expect(string_val_response.response_value).to eql string_val_response.string_val
+        end
+      end
 
+      context 'formatted_response_value' do
+        it 'reutrns the string_val text' do
+          expect(string_val_response.formatted_response_value).to eql string_val_response.string_val
+        end
+      end
+    end
+  end
+
+  context 'text_val' do
+    let(:text_val_response) { create(:text_val_response, submission: submission,
+                                                         question:   grant.form.questions.where(response_type: 'long_text').first)}
+
+    context '#validations' do
+      it 'validates response to a question from the grant' do
+        expect(text_val_response).to be_valid
+      end
+
+      it 'requires response when question is_mandatory' do
+        text_val_response.question.update_attribute(:is_mandatory, true)
+        text_val_response.update_attribute(:text_val, '')
+        expect(text_val_response).not_to be_valid
+        expect(text_val_response.errors).to include(:text_val)
+      end
+
+      it 'requires response to be to a question from its grant' do
+        text_val_response.update_attribute(:grant_submission_question_id, other_grant.form.questions.where(response_type: 'long_text').first.id)
+        expect(text_val_response).not_to be_valid
+        expect(text_val_response.errors).to include(:grant_submission_question_id)
+      end
+
+      it 'validates length' do
+        text_val_response.update_attribute(:text_val, Faker::Lorem.characters(number: 4001))
+        expect(text_val_response).not_to be_valid
+        expect(text_val_response.errors).to include(:text_val)
+      end
+
+      it 'does not allow an attachment' do
+        text_val_response.document.attach(io: File.open(Rails.root.join('spec', 'support', 'file_upload', 'text_file.pdf')), filename: 'text_file.pdf')
+        expect(text_val_response).not_to be_valid
+        expect(text_val_response.errors).to include(:document)
+      end
+    end
+
+    context '#methods' do
+      context 'response_value' do
+        it 'reutrns the text_val text' do
+          expect(text_val_response.response_value).to eql text_val_response.text_val
+        end
+      end
+
+      context 'formatted_response_value' do
+        it 'reutrns the text_val text' do
+          expect(text_val_response.formatted_response_value).to eql text_val_response.text_val
+        end
+      end
+    end
+  end
+
+  context 'number' do
+    let(:number_response) { build(:number_response, submission: submission,
+                                                    question:   grant.form.questions.where(response_type: 'number').first)}
+
+    context '#validations' do
+      # String input specs in spec/system/grant_submission_response_spec.rb
+      it 'validates response to a question from the grant' do
+        expect(number_response).to be_valid
+      end
+
+      it 'requires response when question is_mandatory' do
+        number_response.question.update_attribute(:is_mandatory, true)
+        number_response.update_attribute(:decimal_val, '')
+        expect(number_response).not_to be_valid
+        expect(number_response.errors).to include(:decimal_val)
+      end
+
+      it 'requires response to be to a question from its grant' do
+        number_response.update_attribute(:grant_submission_question_id, other_grant.form.questions.where(response_type: 'number').first.id)
+        expect(number_response).not_to be_valid
+        expect(number_response.errors).to include(:grant_submission_question_id)
+      end
+
+      it 'does not allow an attachment' do
+        number_response.document.attach(io: File.open(Rails.root.join('spec', 'support', 'file_upload', 'text_file.pdf')), filename: 'text_file.pdf')
+        expect(number_response).not_to be_valid
+        expect(number_response.errors).to include(:document)
+      end
+    end
+
+    context '#methods' do
+      context 'response_value' do
+        it 'reutrns the decimal_val text' do
+          expect(number_response.response_value).to eql number_response.decimal_val
+        end
+      end
+
+      context 'formatted_response_value' do
+        it 'reutrns the decimal_val text' do
+          expect(number_response.formatted_response_value).to eql number_response.decimal_val.to_s
+        end
+      end
+    end
+  end
+
+  context 'multiple_choice_option' do
+    let(:pick_one_question) { grant.form.questions.where(response_type: 'pick_one').first }
+    let(:other_question)    { build(:pick_one_question_with_options) }
+    let(:options)           { pick_one_question.multiple_choice_options }
+    let(:pick_one_response) { build(:pick_one_response, submission: submission,
+                                                        question:   pick_one_question,
+                                                        multiple_choice_option: options.first) }
+
+    context '#validations' do
+      it 'validates response to a question from the grant' do
+        expect(pick_one_response).to be_valid
+      end
+
+      it 'requires a choice if is_mandatory' do
+        pick_one_question.is_mandatory = true
+        pick_one_response.multiple_choice_option = nil
+        expect(pick_one_response).not_to be_valid
+        expect(pick_one_response.errors).to include(:grant_submission_multiple_choice_option_id)
+      end
+
+      it 'requires multiple_choice_option to be from the same question' do
+        other_question.save
+        pick_one_response.multiple_choice_option = other_question.multiple_choice_options.first
+        expect(pick_one_response).not_to be_valid
+      end
+    end
+
+    context '#methods' do
+      context 'response_value' do
+        it 'reutrns the multiple_choice_option text' do
+          expect(pick_one_response.response_value).to eql options.first.text
+        end
+      end
+
+      context 'formatted_response_value' do
+        it 'returns the multiple_choice_option text' do
+          expect(pick_one_response.formatted_response_value).to eql options.first.text
+        end
+      end
+    end
+  end
+
+  context 'date_opt_time' do
+    let(:date_response) { build(:date_opt_time_response, submission: submission,
+                                                          question:   grant.form.questions.where(response_type: 'date_opt_time').first)}
+
+    context '#validations' do
+      it 'validates response to a question from the grant' do
+        expect(date_response).to be_valid
+      end
+
+      it 'requires response when question is_mandatory' do
+        date_response.question.update_attribute(:is_mandatory, true)
+        date_response.update_attribute(:datetime_val, '')
+        expect(date_response).not_to be_valid
+        expect(date_response.errors).to include(:datetime_val_date_optional_time_magik)
+      end
+
+      pending 'requires a response to be a date' do
+        fail 'See #295: review DateOptionalTime has_date_optional_time method'
+      end
+
+      it 'requires response to be to a question from its grant' do
+        date_response.update_attribute(:grant_submission_question_id, other_grant.form.questions.where(response_type: 'number').first.id)
+        expect(date_response).not_to be_valid
+        expect(date_response.errors).to include(:grant_submission_question_id)
+      end
+
+      it 'does not allow an attachment' do
+        date_response.document.attach(io: File.open(Rails.root.join('spec', 'support', 'file_upload', 'text_file.pdf')), filename: 'text_file.pdf')
+        expect(date_response).not_to be_valid
+        expect(date_response.errors).to include(:document)
+      end
+    end
+  end
+
+  context 'file_upload' do
+    let(:grant)                { create(:open_grant_with_users_and_form_and_submission_and_reviewer)}
+    let(:file_upload_question) { create(:file_upload_question, section: grant.form.sections.first,
+                                                               display_order: grant.form.questions.pluck(:display_order).max + 1) }
+    context '#validations' do
       context 'valid file type upload' do
-        let(:response) { build(:valid_file_upload_response, submission: grant.submissions.first,
-                                                             question: file_upload_question) }
+        let(:file_upload_response) { build(:valid_file_upload_response, submission: grant.submissions.first,
+                                                                        question: file_upload_question) }
 
         it 'validates response with a attached file' do
-          expect(response.document.attached?).to be true
-          expect(response).to be_valid
+          expect(file_upload_response.document.attached?).to be true
+          expect(file_upload_response).to be_valid
         end
 
         it 'requires a files size below 15MB' do
-          expect(response).to be_valid
-          allow(response.document).to receive_message_chain(:filename, :extension_with_delimiter).and_return('.pdf')
-          allow(response.document).to receive_message_chain(:blob, :byte_size).and_return(16.megabytes)
-          expect(response).not_to be_valid
+          expect(file_upload_response).to be_valid
+          allow(file_upload_response.document).to receive_message_chain(:filename, :extension_with_delimiter).and_return('.pdf')
+          allow(file_upload_response.document).to receive_message_chain(:blob, :byte_size).and_return(16.megabytes)
+          expect(file_upload_response).not_to be_valid
         end
       end
 
       context 'invalid file type upload' do
-        let(:response) { build(:invalid_file_upload_response, submission: grant.submissions.first,
-                                                               question: file_upload_question) }
+        let(:file_upload_response) { build(:invalid_file_upload_response, submission: grant.submissions.first,
+                                                                          question: file_upload_question) }
 
         it 'validates response an invalid attached file' do
-          expect(response).not_to be_valid
+          expect(file_upload_response).not_to be_valid
         end
+      end
+    end
+
+    context '#methods' do
+      let(:file_upload_response) { build(:valid_file_upload_response, submission: grant.submissions.first,
+                                                                      question: file_upload_question) }
+
+      it 'removes attached file when remove_document is 1' do
+        file_upload_response.remove_document = 1
+        file_upload_response.remove_document
+        expect(file_upload_response.document.attached?).to be false
+      end
+
+      it 'does not remove attached file when remove_document is 0' do
+        file_upload_response.remove_document = 0
+        file_upload_response.remove_document
+        expect(file_upload_response.document.attached?).to be true
       end
     end
   end

--- a/spec/system/grant_submissions/grant_submission_responses_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_responses_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'GrantSubmission::Responses', type: :system do
     end
 
     context 'invalid submission' do
+      let(:file_upload_question) {@grant.questions.find_by(response_type: 'file_upload')}
+
       context 'single question' do
         scenario 'requires response mandatory short_text question' do
           short_text_question = @grant.questions.where(response_type: 'short_text').first
@@ -47,28 +49,6 @@ RSpec.describe 'GrantSubmission::Responses', type: :system do
           click_button 'Submit'
           expect(page).not_to have_content successful_application_message
           expect(page).to have_content "Response to '#{short_text_question.text}' is required."
-        end
-
-        scenario 'requires response mandatory number question' do
-          number_question = @grant.questions.where(response_type: 'number').first
-          number_question.update_attribute(:is_mandatory, true)
-
-          find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
-          find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
-          click_button 'Submit'
-          expect(page).not_to have_content successful_application_message
-          expect(page).to have_content "Response to '#{number_question.text}' is required."
-        end
-
-        scenario 'number question requires a number response' do
-          number_question = @grant.questions.where(response_type: 'number').first
-
-          find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
-          find_field(number_question.text, with: '').set('Ten')
-          find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
-          click_button 'Submit'
-          expect(page).not_to have_content successful_application_message
-          expect(page).to have_content "Response to '#{number_question.text}' must be a number."
         end
 
         scenario 'requires response mandatory long_text question' do
@@ -94,19 +74,54 @@ RSpec.describe 'GrantSubmission::Responses', type: :system do
           expect(page).to have_content "A selection for '#{multiple_choice_question.text}' is required."
         end
 
-        context 'file_upload' do
-          let(:file_upload_question) {@grant.questions.find_by(response_type: 'file_upload')}
-
-          scenario 'requires a file_upload response' do
-            file_upload_question.update_attribute(:is_mandatory, true)
+        context 'number' do
+          scenario 'requires response mandatory number question' do
+            number_question = @grant.questions.where(response_type: 'number').first
+            number_question.update_attribute(:is_mandatory, true)
 
             find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
-            find_field('Number Question', with:'').set(Faker::Number.number(digits: 10))
             find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
             click_button 'Submit'
             expect(page).not_to have_content successful_application_message
+            expect(page).to have_content "Response to '#{number_question.text}' is required."
           end
 
+          scenario 'number question requires a number response' do
+            number_question = @grant.questions.where(response_type: 'number').first
+
+            find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
+            find_field(number_question.text, with: '').set('Ten')
+            find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
+            click_button 'Submit'
+            expect(page).not_to have_content successful_application_message
+            expect(page).to have_content "Response to '#{number_question.text}' must be a number."
+          end
+
+          scenario 'number question requires a number-only response' do
+            number_question = @grant.questions.where(response_type: 'number').first
+
+            find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
+            find_field(number_question.text, with: '').set('123.00aaa')
+            find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
+            click_button 'Submit'
+            expect(page).not_to have_content successful_application_message
+            expect(page).to have_content "Response to '#{number_question.text}' must be a number."
+          end
+        end
+
+        scenario 'requires a file_upload response' do
+          file_upload_question.update_attribute(:is_mandatory, true)
+          find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
+          find_field('Number Question', with:'').set(Faker::Number.number(digits: 10))
+          find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
+
+          click_button 'Submit'
+          expect(page).not_to have_content successful_application_message
+        end
+      end
+
+      context 'combined questions' do
+        context 'file_upload' do
           context 'with another invalid response' do
             before(:each) do
               find_field('Number Question', with:'').set('Number')
@@ -116,10 +131,14 @@ RSpec.describe 'GrantSubmission::Responses', type: :system do
               expect(page).to have_link 'text_file.pdf'
             end
 
-            scenario 'submits file successfully when file when another field is invalid' do
-              find_field('Number Question').set(10)
+            scenario 'submits file successfully when file when validation error is corrected' do
+              find_field('Number Question').set('Number')
+              page.attach_file(file_upload_question.text, Rails.root.join('spec', 'support', 'file_upload', 'text_file.pdf'))
+              click_button 'Submit'
+              find_field('Number Question', with: 'Number').set(10)
               click_button 'Submit'
               expect(page).to have_content successful_application_message
+              expect(GrantSubmission::Response.find_by(question: file_upload_question).document.attached?).to be true
             end
           end
         end


### PR DESCRIPTION
Closes #291 and #290 

Adds or improves specs, factories, and error messages for responses to different GrantSubmission::Question response_type options.