### PR TITLE
Specs for request approval/rejection mailers #300

### DIFF
--- a/app/controllers/grant_creator_requests/review_controller.rb
+++ b/app/controllers/grant_creator_requests/review_controller.rb
@@ -2,8 +2,7 @@ module GrantCreatorRequests
   class ReviewController < GrantCreatorRequestsController
     before_action :set_and_authorize_grant_creator_request
 
-    def show
-    end
+    def show; end
 
     def update
       @grant_creator_request.reviewer = current_user

--- a/app/views/grant_creator_requests/edit.html.haml
+++ b/app/views/grant_creator_requests/edit.html.haml
@@ -16,4 +16,4 @@
   - elsif current_user.system_admin?
     .grid-x
       .cell.small-12
-        = link_to 'Review This Grant', grant_creator_request_review_path(@grant_creator_request), class: 'button'
+        = link_to 'Review This Grant Creation Access Request', grant_creator_request_review_path(@grant_creator_request), class: 'button'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,7 @@ RSpec.configure do |config|
   # DEVISE
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Warden::Test::Helpers
 
   config.append_after(:each) do

--- a/spec/requests/grant_creator_requests/review_requests_spec.rb
+++ b/spec/requests/grant_creator_requests/review_requests_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'review requests', type: :request do
+  before(:example) do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  context 'pending' do
+    before(:each) do
+      @system_admin_user = create(:system_admin_user)
+      sign_in @system_admin_user
+    end
+
+    let(:request) { create(:grant_creator_request) }
+
+    context '#show' do
+      it 'can be viewed' do
+        get(grant_creator_request_review_path(grant_creator_request_id: request.id))
+        expect(response).to have_http_status :success
+      end
+    end
+
+    context '#update' do
+      context 'pending status' do
+        it 'does not send an email if the request is pending' do
+          patch(grant_creator_request_review_path(grant_creator_request_id: request.id),
+                                                  params: {
+                                                    grant_creator_request: {
+                                                      status: 'pending' } } )
+          expect(ActionMailer::Base.deliveries.size).to eq(0)
+        end
+      end
+
+      context 'approved status' do
+        it 'sends approved GrantCreatorRequestReviewMailer email when approved' do
+          patch(grant_creator_request_review_path(grant_creator_request_id: request.id),
+                                                  params: { grant_creator_request: { status: 'approved' } })
+          expect(ActionMailer::Base.deliveries.size).to eq(1)
+          email = (ActionMailer::Base.deliveries).first
+          expect(email.subject).to eq('CD2H Competitions - Approved Grant Creator Request')
+        end
+      end
+
+      context 'rejected status' do
+        it 'sends rejected GrantCreatorRequestReviewMailer email when the request is rejected' do
+          patch(grant_creator_request_review_path(grant_creator_request_id: request.id),
+                                                  params: { grant_creator_request: { status: 'rejected' } })
+          expect(ActionMailer::Base.deliveries.size).to eq(1)
+          email = (ActionMailer::Base.deliveries).first
+          expect(email.subject).to eq('CD2H Competitions - Rejected Grant Creator Request')
+        end
+      end
+
+      context 'invalid review' do
+        it 'does not send an email' do
+          allow_any_instance_of(GrantCreatorRequest).to receive(:update).and_return(false)
+          put(grant_creator_request_review_path(grant_creator_request_id: request.id),
+                                                  params: { grant_creator_request: { status: 'invalid_status' } })
+          expect(ActionMailer::Base.deliveries.size).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -18,6 +18,4 @@ RSpec.configure do |config|
     @request.env["devise.mapping"] = Devise.mappings[:user]
     sign_in user
   end
-
-
 end


### PR DESCRIPTION
- Specs to confirm that GrantCreatorRequest notification emails are properly sent upon approval/review. 

Related to #293 
Closes #300  