### PR TITLE
Move grant Duplicate link to Grants pages #324

### DIFF
--- a/app/helpers/grants_helper.rb
+++ b/app/helpers/grants_helper.rb
@@ -8,15 +8,13 @@ module GrantsHelper
   def populate_grant_tabs(grant_permission_role:, grant:)
     case grant_permission_role
     when 'editor', 'admin'
-      tabs = { 'View'             => grant_path(grant),
-               'Submission Form' => edit_grant_form_path(grant, grant.form),
-               'Review Criteria' => criteria_grant_path(grant),
-               'Submissions'     => grant_submissions_path(grant),
-               'Reviewers'       => grant_reviewers_path(grant),
-               'Reviews'         => grant_reviews_path(grant),
-               'Permissions'     => grant_grant_permissions_path(grant) }
-      tabs.merge!( {'Duplicate' => new_grant_duplicate_path(grant) } ) if policy(grant).duplicate?
-      tabs
+      { 'View'             => grant_path(grant),
+        'Submission Form' => edit_grant_form_path(grant, grant.form),
+        'Review Criteria' => criteria_grant_path(grant),
+        'Submissions'     => grant_submissions_path(grant),
+        'Reviewers'       => grant_reviewers_path(grant),
+        'Reviews'         => grant_reviews_path(grant),
+        'Permissions'     => grant_grant_permissions_path(grant) }
     when 'viewer'
       { 'View'            => grant_path(grant),
         'Submission Form' => edit_grant_form_path(grant, grant.form),

--- a/app/views/grants/_sortable_table.html.haml
+++ b/app/views/grants/_sortable_table.html.haml
@@ -12,7 +12,6 @@
       %th
         = sort_link(q, :submission_close_date)
       %th
-      %th
 
   %tbody
     - grants.each do |grant|
@@ -22,5 +21,8 @@
         %td= grant.publish_date
         %td= grant.submission_open_date
         %td= grant.submission_close_date
-        %td= link_to 'Edit', edit_grant_path(grant) if policy(grant).edit?
-        %td= link_to 'Delete', grant, method: :delete, data: { confirm: 'Are you sure?' } if policy(grant).destroy? && grant_can_be_deleted?(grant)
+        %td
+          %ul.menu
+            %li= link_to 'Edit', edit_grant_path(grant) if policy(grant).edit?
+            %li= link_to 'Delete', grant, method: :delete, data: { confirm: 'Are you sure?' } if policy(grant).destroy? && grant_can_be_deleted?(grant)
+            %li= link_to 'Duplicate', new_grant_duplicate_path(grant) if policy(grant).duplicate?

--- a/spec/services/grant_services/duplicate_spec.rb
+++ b/spec/services/grant_services/duplicate_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe GrantServices do
   describe 'DuplicateDependencies' do
     before(:each) do
-      # @original_grant = create(:grant, :with_users)
       @original_grant = create(:grant_with_users)
       @new_grant      = create(:grant, duplicate: true,
                                              name: 'New Name',

--- a/spec/system/grant_submissions/grant_submission_submissions_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_submissions_spec.rb
@@ -1,70 +1,189 @@
 require 'rails_helper'
 
-RSpec.describe 'GrantSubmission::Submissions', type: :system do
-  describe 'Published Open Grant', js: true do
+RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
+  context '#index' do
     before(:each) do
-      @grant = create(:open_grant_with_users_and_form_and_submission_and_reviewer)
-      @editor      = @grant.editors.first
-      @applicant   = create(:user)
+      @grant        = create(:open_grant_with_users_and_form_and_submission_and_reviewer)
+      @submission   = @grant.submissions.first
+      @system_admin = create(:system_admin_user)
+      @grant_admin  = @grant.editors.first
+      @grant_editor = @grant.editors.second
+      @grant_viewer = @grant.editors.third
     end
 
-    context 'applicant' do
+    context 'published grant' do
+      context 'system_admin' do
+        before(:each) do
+          login_as(@system_admin)
+        end
+
+        scenario 'can visit the submissions index page' do
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
+      end
+
+      context 'grant_admin' do
+        scenario 'can visit the submissions index page' do
+          login_as(@grant_admin)
+
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
+      end
+
+      context 'editor' do
+        scenario 'can visit the submissions index page' do
+          login_as(@grant_editor)
+
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
+      end
+
+      context 'viewer' do
+        scenario 'can visit the submissions index page' do
+          login_as(@grant_viewer)
+
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
+      end
+    end
+
+    context 'draft grant' do
       before(:each) do
-        login_as(@applicant)
-        visit grant_apply_path(@grant)
+        @grant.update_attributes(state: 'draft')
       end
 
-      scenario 'can visit apply page' do
-        expect(page).not_to have_content 'You are not authorized to perform this action.'
+      context 'system_admin' do
+        scenario 'can visit the submissions index page' do
+          login_as(@system_admin)
+
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
       end
 
-      scenario 'can submit a valid submission' do
-        find_field('Your Project\'s Title', with: '').set(Faker::Lorem.sentence)
-        find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
-        find_field('Number Question', with:'').set(Faker::Number.number(digits: 10))
-        find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
-        click_button 'Submit'
-        expect(page).to have_content 'You successfully applied'
+      context 'grant_admin' do
+        scenario 'can visit the submissions index page' do
+          login_as(@grant_admin)
+
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
       end
 
-      scenario 'requires a title' do
-        short_text_question = @grant.questions.where(response_type: 'short_text').first
-        short_text_question.update_attribute(:is_mandatory, true)
+      context 'editor' do
+        scenario 'can visit the submissions index page' do
+          login_as(@grant_editor)
 
-        find_field('Number Question', with:'').set(Faker::Number.number(digits: 10))
-        find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
-        click_button 'Submit'
-        expect(page).not_to have_content 'You successfully applied'
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
+      end
+
+      context 'viewer' do
+        scenario 'can visit the submissions index page' do
+          login_as(@grant_viewer)
+
+          visit grant_submissions_path(@grant)
+          expect(page).to have_content @submission.title
+          expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
+          expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
+        end
       end
     end
   end
 
-  describe 'Draft Grant', js: true do
-    before(:each) do
-      @draft_grant = create(:draft_grant)
-      @editor      = @draft_grant.editors.first
-      @applicant   = create(:user)
+  context 'apply' do
+    describe 'Published Open Grant', js: true do
+      before(:each) do
+        @grant     = create(:open_grant_with_users_and_form_and_submission_and_reviewer)
+        @editor    = @grant.editors.first
+        @applicant = create(:user)
+      end
+
+      context 'applicant' do
+        before(:each) do
+          login_as(@applicant)
+          visit grant_apply_path(@grant)
+        end
+
+        scenario 'can visit apply page' do
+          expect(page).not_to have_content 'You are not authorized to perform this action.'
+        end
+
+        scenario 'can submit a valid submission' do
+          find_field('Your Project\'s Title', with: '').set(Faker::Lorem.sentence)
+          find_field('Short Text Question', with:'').set(Faker::Lorem.sentence)
+          find_field('Number Question', with:'').set(Faker::Number.number(digits: 10))
+          find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
+          click_button 'Submit'
+          expect(page).to have_content 'You successfully applied'
+        end
+
+        scenario 'requires a title' do
+          short_text_question = @grant.questions.where(response_type: 'short_text').first
+          short_text_question.update_attribute(:is_mandatory, true)
+
+          find_field('Number Question', with:'').set(Faker::Number.number(digits: 10))
+          find_field('Long Text Question', with:'').set(Faker::Lorem.paragraph_by_chars(number: 1000))
+          click_button 'Submit'
+          expect(page).not_to have_content 'You successfully applied'
+        end
+      end
     end
 
-    context 'editor' do
+    describe 'Draft Grant', js: true do
       before(:each) do
-        login_as(@editor)
-        visit grant_apply_path(@draft_grant)
+        @draft_grant = create(:draft_grant)
+        @editor      = @draft_grant.editors.first
+        @applicant   = create(:user)
       end
 
-      scenario 'can visit apply page' do
-        expect(page).not_to have_content 'You are not authorized to perform this action.'
-      end
-    end
+      context 'editor' do
+        before(:each) do
+          login_as(@editor)
+          visit grant_apply_path(@draft_grant)
+        end
 
-    context 'applicant' do
-      before(:each) do
-        login_as(@applicant)
-        visit grant_apply_path(@draft_grant)
+        scenario 'can visit apply page' do
+          expect(page).not_to have_content 'You are not authorized to perform this action.'
+        end
       end
 
-      scenario 'can visit apply page' do
-        expect(page).to have_content 'You are not authorized to perform this action.'
+      context 'applicant' do
+        before(:each) do
+          login_as(@applicant)
+          visit grant_apply_path(@draft_grant)
+        end
+
+        scenario 'can visit apply page' do
+          expect(page).to have_content 'You are not authorized to perform this action.'
+        end
       end
     end
   end


### PR DESCRIPTION
- Remove Duplicate link from Grant header tabs
- Add Duplicate link to MyGrants and All Grants pages
- Add submissions index system spec
- Expand grant duplicate system spec