### PR TITLE
Grant viewer role bugfixes 

### DIFF
--- a/app/controllers/grant_permissions_controller.rb
+++ b/app/controllers/grant_permissions_controller.rb
@@ -98,6 +98,7 @@ class GrantPermissionsController < ApplicationController
   def unassigned_users_by_grant
     User.left_outer_joins(:grant_permissions)
         .where.not(id: @grant.grant_permissions.map(&:user_id))
+        .distinct
   end
 
   def grant_permission_params

--- a/app/views/grant_submissions/forms/_form.html.erb
+++ b/app/views/grant_submissions/forms/_form.html.erb
@@ -48,3 +48,10 @@
     </div>
   <% end %>
 <% end %>
+<% if disable_fields %>
+  <script>
+    document.addEventListener("trix-initialize", function(event) {
+      event.target.contentEditable = false;
+    });
+  </script>
+<% end %>

--- a/app/views/grant_submissions/forms/_section_form.html.erb
+++ b/app/views/grant_submissions/forms/_section_form.html.erb
@@ -7,7 +7,7 @@
   <table class="section_table table unstriped">
     <tr>
       <td><%= section.label :title %></td>
-      <td><%= section.text_field(attribute: :title) %></td>
+      <td><%= section.text_field(attribute: :title, options: { disabled: !(has_edit_permission) }) %></td>
     </tr>
   </table>
 

--- a/lib/grant_submission_form_builder.rb
+++ b/lib/grant_submission_form_builder.rb
@@ -5,17 +5,17 @@ class GrantSubmissionFormBuilder < ActionView::Helpers::FormBuilder
   attr_accessor :read_only
 
   def text_field(attribute:, options: {})
-    options.reverse_merge!(readonly: grant_disable_input?)
+    options.reverse_merge!(readonly: grant_disable_input?) unless options[:disabled]
     super(attribute, options)
   end
 
   def text_area(attribute:, options: {})
-    options.reverse_merge!(readonly: grant_disable_input?)
+    options.reverse_merge!(readonly: grant_disable_input?) unless options[:disabled]
     super(attribute, options)
   end
 
   def select(method:, choices:, options: {}, html_options: {})
-    html_options.reverse_merge!(disabled: grant_disable_input?)
+    html_options[:disabled] = grant_disable_input? unless html_options[:disabled]
     super(method, choices, options, html_options)
   end
 

--- a/spec/system/grant_submissions/grant_submission_forms_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_forms_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe 'GrantSubmission::Forms', type: :system do
         expect(page).to have_button 'Save'
       end
 
+      scenario 'has enabled inputs' do
+        expect(page).not_to have_field 'Section Title', disabled: true
+        expect(page).not_to have_field 'Question Text', disabled: true
+        expect(page).not_to have_field 'Required', disabled: true
+        expect(page).not_to have_field 'Help Text', disabled: true
+      end
+
       context 'section' do
         scenario 'can be added to a form' do
           expect do
@@ -108,6 +115,13 @@ RSpec.describe 'GrantSubmission::Forms', type: :system do
       scenario 'has edit links' do
         expect(page).not_to have_link add_section_text
         expect(page).not_to have_button 'Save'
+      end
+
+      scenario 'has disabled inputs' do
+        expect(page).to have_field 'Section Title', disabled: true
+        expect(page).to have_field 'Question Text', disabled: true
+        expect(page).to have_field 'Required', disabled: true
+        expect(page).to have_field 'Help Text', disabled: true
       end
     end
   end


### PR DESCRIPTION
Found during #303 

- Add grant admin drop down included duplicates
- Select inputs were enabled for viewers on Submission Form