### PR TITLE
task/move long text response field under question

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -73,7 +73,7 @@ th {
   text-align: left;
 }
 
-label.required-true:after {
+label.required-true p:last-of-type::after {
   content: ' *';
   font-size: 1.15em;
   color: red;

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -73,7 +73,9 @@ th {
   text-align: left;
 }
 
-label.required-true p:last-of-type::after {
+// submission labels contain paragraphs
+//   see: grant_submission_responses.scss
+main:not(.submissions) label.required-true:after {
   content: ' *';
   font-size: 1.15em;
   color: red;

--- a/app/assets/stylesheets/grant_submission_response.scss
+++ b/app/assets/stylesheets/grant_submission_response.scss
@@ -1,4 +1,9 @@
 main.submissions {
+  label.required-true p:last-of-type::after {
+    content: ' *';
+    font-size: 1.15em;
+    color: red;
+  }
   fieldset {
     legend {
       font-weight: bold;

--- a/app/views/grant_submissions/submissions/_section_fields.html.erb
+++ b/app/views/grant_submissions/submissions/_section_fields.html.erb
@@ -3,52 +3,15 @@
       <% f.object.responses.detect { |r| r.question == q } || f.object.responses.build(question: q) %>
   <% end %>
   <%= f.fields_for :responses, responses do |ff| %>
-      <tr class="question question-<%= ff.object.question.id %>">
-        <% ffn = ff.object.form_field_name %>
-        <% is_mandatory = ff.object.question.is_mandatory %>
-        <td style="min-width: 200px">
-          <div>
-            <% if ff.object.submission == f.object %>
-                <%= ff.hidden_field :grant_submission_question_id %>
-            <% end %>
-            <%= ff.label(ffn, simple_format(ff.object.question.text), class: "required-#{is_mandatory}") %>
-          </div>
-        </td>
-        <td>
-          <div>
-            <% if ff.object.submission == f.object %>
-                <% case ff.object.question.response_type.to_sym
-                   when :pick_one %>
-                    <%= ff.select(method: ffn,
-                                  choices: options_for_select(ff.object.question.multiple_choice_options.sort_by(&:display_order).map { |option| [option.text, option.id, 'data-value' => option.text] }, ff.object.grant_submission_multiple_choice_option_id),
-                                  options: { include_blank: true, required: ff.object.question.is_mandatory },
-                                  html_options: { data: { question_id: ff.object.question.id } }) %>
-                <% when :number %>
-                    <%= ff.text_field(attribute: ffn,
-                                      options: { required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id }}) %>
-                <% when :short_text %>
-                    <%= ff.text_area(attribute: ffn,
-                                     options: { rows: 1, cols: 30, required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } }) %>
-                <% when :long_text %>
-                    <%= ff.text_area(attribute: ffn,
-                                     options: { rows: 5, cols: 31, required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } }) %>
-                <% when :date_opt_time %>
-                    <%= ff.date_opt_time_field :datetime_val, :boolean_val, options: { required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } } %>
-                <% when :file_upload %>
-                    <%= ff.file_upload_field(has_saved_file: (ff.object.document && ff.object.document.attached?),
-                                             file_field: ffn,
-                                             remove_document: :remove_document,
-                                             document: ff.object.document,
-                                             required: ff.object.question.is_mandatory) %>
-                <% end %>
-            <% else %>
-                <%= ff.object.formatted_response_value %>
-            <% end %>
-            <% if ff.object.question.instruction.present? %>
-              <p class="helper-text">Instruction: <%= simple_format(ff.object.question.instruction, {}, wrapper_tag: 'span') %></p>
-          <% end %>
-          </div>
-        </td>
-      </tr>
+    <%# field_name = ff.object.form_field_name %>
+    <%# is_mandatory = ff.object.question.is_mandatory %>
+    <% if ff.object.submission == f.object %>
+      <% case ff.object.question.response_type.to_sym
+         when :long_text %>
+           <%= render partial: 'grant_submissions/submissions/responses/long_text_response', locals: { f: f, ff: ff } %>
+         <% else %>
+           <%= render partial: 'grant_submissions/submissions/responses/response', locals: { f: f, ff: ff } %>
+      <% end %>
+    <% end %>
   <% end %>
 </table>

--- a/app/views/grant_submissions/submissions/responses/_long_text_response.html.erb
+++ b/app/views/grant_submissions/submissions/responses/_long_text_response.html.erb
@@ -1,0 +1,24 @@
+<tr class="question question-<%= ff.object.question.id %>">
+  <% ffn = ff.object.form_field_name %>
+  <% is_mandatory = ff.object.question.is_mandatory %>
+  <td colspan="2">
+    <span>
+      <% if ff.object.submission == f.object %>
+          <%= ff.hidden_field :grant_submission_question_id %>
+      <% end %>
+      <%= ff.label(ffn, simple_format(ff.object.question.text), class: "required-#{is_mandatory}") %>
+    </span>
+
+    <div>
+      <% if ff.object.submission == f.object %>
+        <%= ff.text_area(attribute: ffn,
+                         options: { rows: 5, cols: 31, required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } }) %>
+      <% else %>
+          <%= ff.object.formatted_response_value %>
+      <% end %>
+      <% if ff.object.question.instruction.present? %>
+        <p class="helper-text">Instruction: <%= simple_format(ff.object.question.instruction, {}, wrapper_tag: 'span') %></p>
+    <% end %>
+    </div>
+  </td>
+</tr>

--- a/app/views/grant_submissions/submissions/responses/_response.html.erb
+++ b/app/views/grant_submissions/submissions/responses/_response.html.erb
@@ -24,9 +24,6 @@
           <% when :short_text %>
               <%= ff.text_area(attribute: ffn,
                                options: { rows: 1, cols: 30, required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } }) %>
-          <% when :long_text %>
-              <%= ff.text_area(attribute: ffn,
-                               options: { rows: 5, cols: 31, required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } }) %>
           <% when :date_opt_time %>
               <%= ff.date_opt_time_field :datetime_val, :boolean_val, options: { required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } } %>
           <% when :file_upload %>

--- a/app/views/grant_submissions/submissions/responses/_response.html.erb
+++ b/app/views/grant_submissions/submissions/responses/_response.html.erb
@@ -9,7 +9,7 @@
       <%= ff.label(ffn, simple_format(ff.object.question.text), class: "required-#{is_mandatory}") %>
     </span>
   </td>
-  <td>
+  <td style="min-width: 300px;">
     <div>
       <% if ff.object.submission == f.object %>
           <% case ff.object.question.response_type.to_sym

--- a/app/views/grant_submissions/submissions/responses/_response.html.erb
+++ b/app/views/grant_submissions/submissions/responses/_response.html.erb
@@ -1,0 +1,47 @@
+<tr class="question question-<%= ff.object.question.id %>">
+  <% ffn = ff.object.form_field_name %>
+  <% is_mandatory = ff.object.question.is_mandatory %>
+  <td style="min-width: 200px">
+    <span>
+      <% if ff.object.submission == f.object %>
+          <%= ff.hidden_field :grant_submission_question_id %>
+      <% end %>
+      <%= ff.label(ffn, simple_format(ff.object.question.text), class: "required-#{is_mandatory}") %>
+    </span>
+  </td>
+  <td>
+    <div>
+      <% if ff.object.submission == f.object %>
+          <% case ff.object.question.response_type.to_sym
+             when :pick_one %>
+              <%= ff.select(method: ffn,
+                            choices: options_for_select(ff.object.question.multiple_choice_options.sort_by(&:display_order).map { |option| [option.text, option.id, 'data-value' => option.text] }, ff.object.grant_submission_multiple_choice_option_id),
+                            options: { include_blank: true, required: ff.object.question.is_mandatory },
+                            html_options: { data: { question_id: ff.object.question.id } }) %>
+          <% when :number %>
+              <%= ff.text_field(attribute: ffn,
+                                options: { required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id }}) %>
+          <% when :short_text %>
+              <%= ff.text_area(attribute: ffn,
+                               options: { rows: 1, cols: 30, required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } }) %>
+          <% when :long_text %>
+              <%= ff.text_area(attribute: ffn,
+                               options: { rows: 5, cols: 31, required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } }) %>
+          <% when :date_opt_time %>
+              <%= ff.date_opt_time_field :datetime_val, :boolean_val, options: { required: ff.object.question.is_mandatory, data: { question_id: ff.object.question.id } } %>
+          <% when :file_upload %>
+              <%= ff.file_upload_field(has_saved_file: (ff.object.document && ff.object.document.attached?),
+                                       file_field: ffn,
+                                       remove_document: :remove_document,
+                                       document: ff.object.document,
+                                       required: ff.object.question.is_mandatory) %>
+          <% end %>
+      <% else %>
+          <%= ff.object.formatted_response_value %>
+      <% end %>
+      <% if ff.object.question.instruction.present? %>
+        <p class="helper-text">Instruction: <%= simple_format(ff.object.question.instruction, {}, wrapper_tag: 'span') %></p>
+    <% end %>
+    </div>
+  </td>
+</tr>


### PR DESCRIPTION
- Adds long_text_response and response partials for use in submission form section.
- CSS changes to account for paragraph tags in required response field labels.

 Closes #354 