### PR TITLE
task/admin may switch to draft

### DIFF
--- a/app/controllers/grant_submissions/submissions/unsubmit_controller.rb
+++ b/app/controllers/grant_submissions/submissions/unsubmit_controller.rb
@@ -1,0 +1,22 @@
+module GrantSubmissions
+  module Submissions
+    class UnsubmitController < SubmissionsController
+      def update
+        set_submission
+        authorize @submission, :unsubmit?
+
+        if @submission.draft?
+          flash[:warning] = 'This submission is already editable.'
+        elsif @submission.update(state: GrantSubmission::Submission::SUBMISSION_STATES[:draft])
+          flash[:success] = 'You have changed the status of this submission to Draft. It may now be edited by the applicant.'
+        else
+          flash[:alert]   = @submission.errors.full_messages
+        end
+
+        respond_to do |format|
+          format.html { redirect_back fallback_location: grant_submissions_path(@grant) }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/grant_submissions/submissions_controller.rb
+++ b/app/controllers/grant_submissions/submissions_controller.rb
@@ -113,7 +113,7 @@ module GrantSubmissions
                       when 'create'
                         @grant.submissions.build(submission_params.merge(created_id: current_user.id))
                       else
-                        @grant.submissions.find(params[:id]) if params[:id]
+                        @grant.submissions.kept.find(params[:id]) if params[:id]
                       end
     end
 

--- a/app/models/grant_submission/submission.rb
+++ b/app/models/grant_submission/submission.rb
@@ -79,7 +79,7 @@ module GrantSubmission
     private
 
     def can_be_unsubmitted?
-      errors.add(:base, 'This submission has already been scored and may not be edited.') if self.reviews.completed.any?
+      errors.add(:base, :reviewed_submission_cannot_be_unsubmitted) if self.reviews.completed.any?
     end
   end
 end

--- a/app/policies/grant_submission/submission_policy.rb
+++ b/app/policies/grant_submission/submission_policy.rb
@@ -58,6 +58,10 @@ class GrantSubmission::SubmissionPolicy < GrantPolicy
     !grant.published? && (grant_admin_access?)
   end
 
+  def unsubmit?
+    grant_editor_access?
+  end
+
   private
 
   def submission

--- a/app/views/grant_submissions/submissions/_admin_links.html.haml
+++ b/app/views/grant_submissions/submissions/_admin_links.html.haml
@@ -3,5 +3,7 @@
 %li
   - if submission.draft?
     = link_to 'Edit', edit_grant_submission_path(grant, submission), class: 'button clear'
+  - elsif submission.submitted?
+    = link_to 'Switch to Draft', unsubmit_grant_submission_path(grant, submission), method: :patch, class: 'button clear', title: 'Allow for editing'
 %li
   = link_to 'Delete', grant_submission_path(grant, submission), method: :delete, data: { confirm: 'Are you sure?'}, class: 'button clear alert', confirm: 'Are you sure?' if !grant.published?

--- a/app/views/grant_submissions/submissions/_editor_links.html.haml
+++ b/app/views/grant_submissions/submissions/_editor_links.html.haml
@@ -1,4 +1,7 @@
 %li
   = link_to 'Reviews', grant_submission_reviews_path(@grant, submission), class: 'button clear'
 %li
-  = link_to 'Edit', edit_grant_submission_path(@grant, submission), class: 'button clear'
+  - if submission.draft?
+    = link_to 'Edit', edit_grant_submission_path(grant, submission), class: 'button clear'
+  - elsif submission.submitted?
+    = link_to 'Switch to Draft', unsubmit_grant_submission_path(grant, submission), method: :patch, class: 'button clear', title: 'Allow for editing'

--- a/app/views/grant_submissions/submissions/index.html.haml
+++ b/app/views/grant_submissions/submissions/index.html.haml
@@ -42,7 +42,7 @@
             %td
               = link_to submission.title, grant_submission_path(@grant, submission)
             %td
-              = submission.state
+              = submission.state.titleize
             %td
               = submission.created_at
             %td

--- a/config/locales/activerecord/grant_submission_submission.yml
+++ b/config/locales/activerecord/grant_submission_submission.yml
@@ -8,6 +8,8 @@ en:
       models:
         grant_submission/submission:
           attributes:
+            base:
+              reviewed_submission_cannot_be_unsubmitted: This submission has already been scored and may not be edited.
             responses:
               invalid: have highlighted errors.
     models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,9 @@ Rails.application.routes.draw do
       end
     end
     resources :submissions,       except: %i[new],  controller: 'grant_submissions/submissions' do
+      member do
+        patch 'unsubmit',         to: 'grant_submissions/submissions/unsubmit#update'
+      end
       resources :reviews,         except: %i[new],  controller: 'grant_submissions/submissions/reviews' do
         delete 'opt_out',         to: 'grant_submissions/submissions/reviews/opt_out#destroy', on: :member
       end

--- a/spec/requests/grant_submissions/submissions/unsubmit_requests_spec.rb
+++ b/spec/requests/grant_submissions/submissions/unsubmit_requests_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'grant_submission unsubmit requests', type: :request do
           end
 
           context 'unscored' do
-            it 'cannot be unsubmitted' do
+            it 'can be unsubmitted' do
               unscored_review.reload
               patch unsubmit_grant_submission_path(grant_id: grant.id, id: submission.id)
               follow_redirect!

--- a/spec/requests/grant_submissions/submissions/unsubmit_requests_spec.rb
+++ b/spec/requests/grant_submissions/submissions/unsubmit_requests_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe 'grant_submission unsubmit requests', type: :request do
+  let(:grant)           { create(:open_grant_with_users_and_form_and_submission_and_reviewer) }
+  let(:grant_editor)    { grant.grant_permissions.role_editor.first.user }
+  let(:grant_viewer)    { grant.grant_permissions.role_viewer.first.user }
+  let(:submission)      { grant.submissions.first }
+  let(:reviewer)        { grant.reviewers.first }
+  let(:scored_review)   { create(:scored_review_with_scored_mandatory_criteria_review, submission: submission,
+                                                                                       assigner: grant_editor,
+                                                                                       reviewer: reviewer) }
+  let(:unscored_review) { create(:incomplete_review, submission: submission,
+                                                     assigner: grant_editor,
+                                                     reviewer: reviewer) }
+
+  context '#update' do
+    before(:each) do
+      sign_in(grant_editor)
+    end
+
+    context 'kept' do
+      context 'submitted' do
+        context 'no reviews' do
+          it 'sucessfully changes the state of the submission' do
+            patch unsubmit_grant_submission_path(grant_id: grant.id, id: submission.id)
+            follow_redirect!
+            expect(response.body).to include('You have changed the status of this submission to Draft. It may now be edited by the applicant.')
+            expect(submission.reload.state).to eql 'draft'
+          end
+        end
+
+        context 'with reviews' do
+          context 'scored' do
+            it 'cannot be unsubmitted' do
+              scored_review.reload
+              patch unsubmit_grant_submission_path(grant_id: grant.id, id: submission.id)
+              follow_redirect!
+              expect(response.body).to include('This submission has already been scored and may not be edited.')
+            end
+          end
+
+          context 'unscored' do
+            it 'cannot be unsubmitted' do
+              unscored_review.reload
+              patch unsubmit_grant_submission_path(grant_id: grant.id, id: submission.id)
+              follow_redirect!
+              expect(response.body).to include('You have changed the status of this submission to Draft. It may now be edited by the applicant.')
+              expect(submission.reload.state).to eql 'draft'
+            end
+          end
+        end
+      end
+
+      context 'draft' do
+        it 'does not change status' do
+          submission.update_attribute(:state, GrantSubmission::Submission::SUBMISSION_STATES[:draft])
+          patch unsubmit_grant_submission_path(grant_id: grant.id, id: submission.id)
+          follow_redirect!
+          expect(response.body).to include('This submission is already editable.')
+          expect(submission.reload.state).to eql 'draft'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/grant_submissions/grant_submission_reviews_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_reviews_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe 'GrantSubmission::Submission Reviews', type: :system do
       scenario 'includes a link to edit the review' do
         login_as grant_editor
         visit grant_submission_review_path(grant, submission, review)
-
         expect(page).to have_link 'Edit', href: edit_grant_submission_review_path(grant, submission, review)
       end
     end

--- a/spec/system/grant_submissions/grant_submission_submissions_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_submissions_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
             expect(page).to have_content @submission.title
             expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
             expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+            expect(page).to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
             expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
           end
         end
@@ -48,7 +49,8 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
           visit grant_submissions_path(@grant)
           expect(page).to have_content @submission.title
           expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
-          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
           expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
         end
       end
@@ -61,6 +63,7 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
           expect(page).to have_content @submission.title
           expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
           expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
           expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
         end
       end
@@ -80,6 +83,7 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
         scenario 'does not have admin links' do
           expect(page).not_to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
           expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
           expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
         end
 
@@ -103,6 +107,7 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
             expect(page).to have_content @submission.title
             expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
             expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+            expect(page).to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
             expect(page).to have_link 'Delete', href: grant_submission_path(@grant, @submission)
           end
         end
@@ -115,6 +120,7 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
             expect(page).to have_content @submission.title
             expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
             expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+            expect(page).to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
             expect(page).to have_link 'Delete', href: grant_submission_path(@grant, @submission)
           end
         end
@@ -127,7 +133,8 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
           visit grant_submissions_path(@grant)
           expect(page).to have_content @submission.title
           expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
-          expect(page).to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
           expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
         end
       end
@@ -140,6 +147,7 @@ RSpec.describe 'GrantSubmission::Submissions', type: :system, js: true do
           expect(page).to have_content @submission.title
           expect(page).to have_link 'Reviews', href: grant_submission_reviews_path(@grant, @submission)
           expect(page).not_to have_link 'Edit', href: edit_grant_submission_path(@grant, @submission)
+          expect(page).not_to have_link 'Switch to Draft', href: unsubmit_grant_submission_path(@grant, @submission)
           expect(page).not_to have_link 'Delete', href: grant_submission_path(@grant, @submission)
         end
       end


### PR DESCRIPTION
Users with at least grant_editor access may move an unreviewed submission from Submitted to Draft state to allow edits. 

Closes #371 
