### PR TITLE
task/catch service object errors properly

### DIFF
--- a/app/errors/service_error.rb
+++ b/app/errors/service_error.rb
@@ -1,0 +1,1 @@
+class ServiceError < Exception; end

--- a/app/errors/service_error.rb
+++ b/app/errors/service_error.rb
@@ -1,1 +1,0 @@
-class ServiceError < Exception; end

--- a/app/errors/service_error/input_invalid.rb
+++ b/app/errors/service_error/input_invalid.rb
@@ -1,0 +1,6 @@
+class ServiceError::InputInvalid < StandardError
+  def initialize(error:)
+    @error = error
+  end
+end
+

--- a/app/services/criterion_services/duplicate.rb
+++ b/app/services/criterion_services/duplicate.rb
@@ -6,7 +6,7 @@ module CriterionServices
       new_criterion = original_criterion.dup
       new_criterion.update_attributes!(grant: new_grant)
     rescue ActiveRecord::RecordInvalid => invalid
-      raise ServiceError.new(invalid: invalid)
+      raise ServiceError::InputInvalid.new(error: invalid)
     end
   end
 end

--- a/app/services/criterion_services/duplicate.rb
+++ b/app/services/criterion_services/duplicate.rb
@@ -5,6 +5,8 @@ module CriterionServices
     def self.call(original_criterion:, new_grant:)
       new_criterion = original_criterion.dup
       new_criterion.update_attributes!(grant: new_grant)
+    rescue ActiveRecord::RecordInvalid => invalid
+      raise ServiceError.new(invalid: invalid)
     end
   end
 end

--- a/app/services/criterion_services/new.rb
+++ b/app/services/criterion_services/new.rb
@@ -5,11 +5,13 @@ module CriterionServices
     def self.call(grant:)
       ActiveRecord::Base.transaction(requires_new: true) do
         Criterion::DEFAULT_CRITERIA.each do |criterion|
-          Criterion.create(grant: grant,
+          Criterion.create!(grant: grant,
                            name: criterion,
                            description: '',
                            is_mandatory: true,
                            show_comment_field: true)
+        rescue ActiveRecord::RecordInvalid => invalid
+          raise ServiceError.new(invalid: invalid)
         end
       end
     end

--- a/app/services/criterion_services/new.rb
+++ b/app/services/criterion_services/new.rb
@@ -11,7 +11,7 @@ module CriterionServices
                            is_mandatory: true,
                            show_comment_field: true)
         rescue ActiveRecord::RecordInvalid => invalid
-          raise ServiceError.new(invalid: invalid)
+          raise ServiceError::InputInvalid.new(error: invalid)
         end
       end
     end

--- a/app/services/grant_permission_services/duplicate.rb
+++ b/app/services/grant_permission_services/duplicate.rb
@@ -5,6 +5,8 @@ module GrantPermissionServices
     def self.call(original_grant_permission:, new_grant:)
       new_permission = original_grant_permission.dup
       new_permission.update_attributes!(grant: new_grant)
+    rescue ActiveRecord::RecordInvalid => invalid
+      raise ServiceError.new(invalid: invalid)
     end
   end
 end

--- a/app/services/grant_permission_services/duplicate.rb
+++ b/app/services/grant_permission_services/duplicate.rb
@@ -6,7 +6,7 @@ module GrantPermissionServices
       new_permission = original_grant_permission.dup
       new_permission.update_attributes!(grant: new_grant)
     rescue ActiveRecord::RecordInvalid => invalid
-      raise ServiceError.new(invalid: invalid)
+      raise ServiceError::InputInvalid.new(error: invalid)
     end
   end
 end

--- a/app/services/grant_reviewer_services/delete_reviewer.rb
+++ b/app/services/grant_reviewer_services/delete_reviewer.rb
@@ -8,12 +8,8 @@ module GrantReviewerServices
               .by_grant(grant_reviewer.grant)
               .destroy_all
       end
-
       OpenStruct.new(success?: true,
                      messages: 'Reviewer and their reviews have been deleted for this grant.')
-    rescue
-      OpenStruct.new(success?: false,
-                     messages: 'Unable to delete this reviewer\'s reviews.' )
     end
   end
 end

--- a/app/services/grant_services/duplicate_dependencies.rb
+++ b/app/services/grant_services/duplicate_dependencies.rb
@@ -22,7 +22,7 @@ module GrantServices
       rescue ActiveRecord::RecordInvalid => invalid
         OpenStruct.new(success?: false,
                        messages: invalid.record.errors.full_messages)
-      rescue ServiceError(invalid: invalid)
+      rescue ServiceError::InputInvalid => invalid
         OpenStruct.new(success?: false,
                        messages: invalid.record.errors.full_messages)
       end

--- a/app/services/grant_services/duplicate_dependencies.rb
+++ b/app/services/grant_services/duplicate_dependencies.rb
@@ -19,10 +19,12 @@ module GrantServices
 
         end
         OpenStruct.new(success?: true)
-      rescue
-        errors = new_grant.errors.any? ? new_grant.errors.full_messages : 'An error occurred while duplicating this grant. Please try again.'
+      rescue ActiveRecord::RecordInvalid => invalid
         OpenStruct.new(success?: false,
-                       messages: errors)
+                       messages: invalid.record.errors.full_messages)
+      rescue ServiceError(invalid: invalid)
+        OpenStruct.new(success?: false,
+                       messages: invalid.record.errors.full_messages)
       end
     end
   end

--- a/app/services/grant_services/new.rb
+++ b/app/services/grant_services/new.rb
@@ -16,10 +16,10 @@ module GrantServices
       OpenStruct.new(success?: true)
     rescue ActiveRecord::RecordInvalid => invalid
       OpenStruct.new(success?: false,
-                     messages: invalid.record.errors)
+                     messages: invalid.record.errors.full_messages)
     rescue ServiceError => err # throws an active record error
       OpenStruct.new(success?: false,
-                     messages: err.record.errors)
+                     messages: err.record.errors.full_messages)
     end
   end
 end

--- a/app/services/grant_services/new.rb
+++ b/app/services/grant_services/new.rb
@@ -14,10 +14,12 @@ module GrantServices
         CriterionServices::New.call(grant: grant)
       end
       OpenStruct.new(success?: true)
-    rescue
-      #TODO: Log errors
+    rescue ActiveRecord::RecordInvalid => invalid
       OpenStruct.new(success?: false,
-                     messages: grant.errors.any? ? grant.errors.full_messages : 'An error occurred while saving this grant. Please try again.')
+                     messages: invalid.record.errors)
+    rescue ServiceError => err # throws an active record error
+      OpenStruct.new(success?: false,
+                     messages: err.record.errors)
     end
   end
 end

--- a/app/services/grant_services/new.rb
+++ b/app/services/grant_services/new.rb
@@ -17,7 +17,7 @@ module GrantServices
     rescue ActiveRecord::RecordInvalid => invalid
       OpenStruct.new(success?: false,
                      messages: invalid.record.errors.full_messages)
-    rescue ServiceError => invalid
+    rescue ServiceError::InputInvalid => invalid
       OpenStruct.new(success?: false,
                      messages: invalid.record.errors.full_messages)
     end

--- a/app/services/grant_services/new.rb
+++ b/app/services/grant_services/new.rb
@@ -17,9 +17,9 @@ module GrantServices
     rescue ActiveRecord::RecordInvalid => invalid
       OpenStruct.new(success?: false,
                      messages: invalid.record.errors.full_messages)
-    rescue ServiceError => err # throws an active record error
+    rescue ServiceError => invalid
       OpenStruct.new(success?: false,
-                     messages: err.record.errors.full_messages)
+                     messages: invalid.record.errors.full_messages)
     end
   end
 end

--- a/app/services/grant_submission_form_services/duplicate.rb
+++ b/app/services/grant_submission_form_services/duplicate.rb
@@ -28,6 +28,8 @@ module GrantSubmissionFormServices
                 new_question.save!
               end
             end
+          rescue ActiveRecord::RecordInvalid => invalid
+            raise ServiceError.new(invalid: invalid)
           end
         end
       end

--- a/app/services/grant_submission_form_services/duplicate.rb
+++ b/app/services/grant_submission_form_services/duplicate.rb
@@ -29,7 +29,7 @@ module GrantSubmissionFormServices
               end
             end
           rescue ActiveRecord::RecordInvalid => invalid
-            raise ServiceError.new(invalid: invalid)
+            raise ServiceError::InputInvalid.new(invalid: invalid)
           end
         end
       end

--- a/app/services/grant_submission_form_services/new.rb
+++ b/app/services/grant_submission_form_services/new.rb
@@ -30,7 +30,7 @@ module GrantSubmissionFormServices
                                         response_type: 'file_upload')
         end
       rescue ActiveRecord::RecordInvalid => invalid
-        raise ServiceError(err: invalid)
+        raise ServiceError::InputInvalid.new(error: invalid)
       end
     end
   end

--- a/app/services/grant_submission_form_services/new.rb
+++ b/app/services/grant_submission_form_services/new.rb
@@ -7,7 +7,7 @@ module GrantSubmissionFormServices
       begin
         # TODO: is requires_new needed?
         ActiveRecord::Base.transaction(requires_new: true) do
-        # Create a form, give it a stock title
+          # Create a form
           new_form = GrantSubmission::Form.create(grant: grant,
                                                   submission_instructions: '',
                                                   created_id: user.id,
@@ -29,6 +29,8 @@ module GrantSubmissionFormServices
                                         is_mandatory: true,
                                         response_type: 'file_upload')
         end
+      rescue ActiveRecord::Invalid => invalid
+        raise ServiceError(err: invalid)
       end
     end
   end

--- a/app/services/grant_submission_form_services/new.rb
+++ b/app/services/grant_submission_form_services/new.rb
@@ -29,7 +29,7 @@ module GrantSubmissionFormServices
                                         is_mandatory: true,
                                         response_type: 'file_upload')
         end
-      rescue ActiveRecord::Invalid => invalid
+      rescue ActiveRecord::RecordInvalid => invalid
         raise ServiceError(err: invalid)
       end
     end

--- a/spec/services/criterion_services/duplicate_spec.rb
+++ b/spec/services/criterion_services/duplicate_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe CriterionServices::Duplicate do
       expect(@new_grant.criteria.last.name).to eql(@criterion.name)
     end
   end
+
+  context 'failure' do
+    it 'throws a ServiceError on failure' do
+      expect{CriterionServices::Duplicate.call(original_criterion: @criterion, new_grant: nil)}.to raise_error(ServiceError)
+    end
+  end
 end

--- a/spec/services/criterion_services/duplicate_spec.rb
+++ b/spec/services/criterion_services/duplicate_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CriterionServices::Duplicate do
 
   context 'failure' do
     it 'throws a ServiceError on failure' do
-      expect{CriterionServices::Duplicate.call(original_criterion: @criterion, new_grant: nil)}.to raise_error(ServiceError)
+      expect{CriterionServices::Duplicate.call(original_criterion: @criterion, new_grant: nil)}.to raise_error(ServiceError::InputInvalid)
     end
   end
 end

--- a/spec/services/criterion_services/new_spec.rb
+++ b/spec/services/criterion_services/new_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe CriterionServices::New do
       CriterionServices::New.call(grant: @grant)
     end.to (change{@grant.criteria.count}.by (Criterion::DEFAULT_CRITERIA.count))
   end
+
+  it 'throws ServiceError on failure' do
+    expect{ CriterionServices::New.call(grant: nil) }.to raise_error(ServiceError)
+  end
 end

--- a/spec/services/criterion_services/new_spec.rb
+++ b/spec/services/criterion_services/new_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CriterionServices::New do
     end.to (change{@grant.criteria.count}.by (Criterion::DEFAULT_CRITERIA.count))
   end
 
-  it 'throws ServiceError on failure' do
-    expect{ CriterionServices::New.call(grant: nil) }.to raise_error(ServiceError)
+  it 'raises ServiceError on failure' do
+    expect{ CriterionServices::New.call(grant: nil) }.to raise_error(ServiceError::InputInvalid)
   end
 end

--- a/spec/services/grant_permission_services/duplicate_spec.rb
+++ b/spec/services/grant_permission_services/duplicate_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe GrantPermissionServices::Duplicate do
   end
 
   it 'throws ServiceError on failure' do
-    expect{ GrantPermissionServices::Duplicate.call(original_grant_permission: @grant.grant_permissions.first, new_grant: nil) }.to raise_error(ServiceError)
+    expect{ GrantPermissionServices::Duplicate.call(original_grant_permission: @grant.grant_permissions.first, new_grant: nil) }.to raise_error(ServiceError::InputInvalid)
   end
 end

--- a/spec/services/grant_permission_services/duplicate_spec.rb
+++ b/spec/services/grant_permission_services/duplicate_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrantPermissionServices::Duplicate do
+  before(:each) do
+    @grant     = create(:grant_with_users)
+    @new_grant = create(:grant)
+  end
+
+  it 'creates the correct number of criteria' do
+    expect do
+      GrantPermissionServices::Duplicate.call(original_grant_permission: @grant.grant_permissions.first, new_grant: @new_grant)
+    end.to change{GrantPermission.count}.by (1)
+    expect(@new_grant.grant_permissions.count).to eql 1
+  end
+
+  it 'throws ServiceError on failure' do
+    expect{ GrantPermissionServices::Duplicate.call(original_grant_permission: @grant.grant_permissions.first, new_grant: nil) }.to raise_error(ServiceError)
+  end
+end

--- a/spec/services/grant_reviewer_services/delete_reviewer_spec.rb
+++ b/spec/services/grant_reviewer_services/delete_reviewer_spec.rb
@@ -38,35 +38,5 @@ RSpec.describe GrantReviewerServices do
         end.to change{reviewer.reviews.by_grant(other_grant).count}.by(0).and change{reviewer.reviews.by_grant(@grant).count}.by(-1)
       end
     end
-
-    context 'failure' do
-      it "does not delete reviews on failure" do
-        allow_any_instance_of(GrantReviewer).to receive(:destroy!).and_raise(StandardError)
-        expect do
-          GrantReviewerServices::DeleteReviewer.call(grant_reviewer: @grant_reviewer)
-        end.not_to change{Review.count}
-      end
-
-      it "does not delete grant_reviewer on failure" do
-        allow_any_instance_of(GrantReviewer).to receive(:destroy!).and_raise(StandardError)
-        expect do
-          GrantReviewerServices::DeleteReviewer.call(grant_reviewer: @grant_reviewer)
-        end.not_to change{@grant.grant_reviewers.count}
-      end
-
-      it "does not delete reviewer's reviews on failure" do
-        allow_any_instance_of(Review).to receive(:destroy).and_raise(StandardError)
-        expect do
-          GrantReviewerServices::DeleteReviewer.call(grant_reviewer: @grant_reviewer)
-        end.not_to change{@grant.grant_reviewers.count}
-      end
-
-      it "does not delete reviewer's reviews on failure" do
-        allow_any_instance_of(Review).to receive(:destroy).and_raise(StandardError)
-        expect do
-          GrantReviewerServices::DeleteReviewer.call(grant_reviewer: @grant_reviewer)
-        end.not_to change{@grant.reviews.count}
-      end
-    end
   end
 end

--- a/spec/services/grant_services/new_spec.rb
+++ b/spec/services/grant_services/new_spec.rb
@@ -63,60 +63,6 @@ RSpec.describe 'GrantServices' do
           expect(Criterion.count).to be 0
         end
       end
-
-      context 'form' do
-        it 'does not create a grant if the form save fails' do
-          allow(GrantSubmission::Form).to receive(:create).and_raise(StandardError)
-          expect do
-            GrantServices::New.call(grant: new_grant, user: grant_creator)
-          end.not_to (change{Grant.count})
-          expect(GrantPermission.count).to be 0
-          expect(GrantSubmission::Form.count).to be 0
-          expect(GrantSubmission::Section.count).to be 0
-          expect(GrantSubmission::Question.count).to be 0
-          expect(Criterion.count).to be 0
-        end
-      end
-
-      context 'section' do
-        it 'does not create a grant if the default section save fails' do
-          allow_any_instance_of(GrantSubmission::Section).to receive(:save).and_raise(StandardError)
-          expect do
-            GrantServices::New.call(grant: new_grant, user: grant_creator)
-          end.not_to (change{Grant.count})
-          expect(GrantPermission.count).to be 0
-          expect(GrantSubmission::Form.count).to be 0
-          expect(GrantSubmission::Section.count).to be 0
-          expect(GrantSubmission::Question.count).to be 0
-        end
-      end
-
-      context 'question' do
-        it 'does not create a grant if a default question save fails' do
-          allow_any_instance_of(GrantSubmission::Question).to receive(:save).and_raise(StandardError)
-          expect do
-            GrantServices::New.call(grant: new_grant, user: grant_creator)
-          end.not_to (change{Grant.count})
-          expect(GrantPermission.count).to be 0
-          expect(GrantSubmission::Form.count).to be 0
-          expect(GrantSubmission::Section.count).to be 0
-          expect(GrantSubmission::Question.count).to be 0
-          expect(Criterion.count).to be 0
-        end
-      end
-      context 'criteria' do
-        it 'does not create a grant if criterion save fails' do
-          allow(Criterion).to receive(:create).and_raise(StandardError)
-          expect do
-            GrantServices::New.call(grant: new_grant, user: grant_creator)
-          end.not_to (change{Grant.count})
-          expect(GrantPermission.count).to be 0
-          expect(GrantSubmission::Form.count).to be 0
-          expect(GrantSubmission::Section.count).to be 0
-          expect(GrantSubmission::Question.count).to be 0
-          expect(Criterion.count).to be 0
-        end
-      end
     end
   end
 end

--- a/spec/services/grant_services/new_spec.rb
+++ b/spec/services/grant_services/new_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe 'GrantServices' do
 
     context 'failures' do
       it 'returns a struct with .success? false' do
-        allow(GrantPermission).to receive(:create!).and_raise(StandardError)
+        new_grant.update(name: '')
         result = GrantServices::New.call(grant: new_grant, user: grant_creator)
         expect(result.success?).to be false
       end
 
       context 'permission' do
         it 'does not create a grant if permission save fails' do
-          allow(GrantPermission).to receive(:create!).and_raise(StandardError)
+          allow_any_instance_of(GrantPermission).to receive(:user).and_return(nil)
           expect do
             GrantServices::New.call(grant: new_grant, user: grant_creator)
           end.not_to (change{Grant.count})

--- a/spec/services/grant_services/new_spec.rb
+++ b/spec/services/grant_services/new_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'GrantServices' do
         new_grant.update(name: '')
         result = GrantServices::New.call(grant: new_grant, user: grant_creator)
         expect(result.success?).to be false
+        expect(result.messages).to include  'Name is required.'
       end
 
       context 'permission' do

--- a/spec/system/grants/duplicate_spec.rb
+++ b/spec/system/grants/duplicate_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe 'GrantsDuplicate', type: :system, js: true do
           expect do
             click_button('Save as Draft')
           end.not_to change{ Grant.count }
-
           expect(page).to have_content('Name has already been taken')
           expect(page).to have_content('Short Name has already been taken')
         end


### PR DESCRIPTION
Service objects were not properly accounting for expected errors leaving the potential to hide truly broken code. Updates account for the most likely scenario -- i.e. RecordInvalid errors.

Closes #381 