### PR TITLE
take out specifics from error pages. #494

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>Competitions - Page Not Found</title>
+    <title>Page Not Found</title>
     <style>
       html { box-sizing: border-box; font-size: 100%; line-height: 1.15; -webkit-text-size-adjust: 100%; }
       body { margin: 0; }
@@ -136,22 +136,6 @@
   <body>
     <div class="grid-container">
       <div class="grid-x grid-margin-x grid-margin-y">
-        <header class="cell">
-          <div class="top-bar">
-            <div class="top-bar-left">
-              <ul class="menu">
-                <li>
-                  <div class="home">
-                    <a href="/">CD2H - Competitions</a>
-                  </div>
-                </li>
-              </ul>
-            </div>
-            <div class="top-bar-right"></div>
-          </div>
-        </header>
-      </div>
-      <div class="grid-x grid-margin-x grid-margin-y">
         <main class="cell" style="min-height: 30em;">
           <div class="grid-x align-center-middle">
             <div class="section-intro">
@@ -170,26 +154,6 @@
         </main>
       </div>
       <div class="grid-x grid-margin-x grid-margin-y">
-      <footer>
-        <div class="grid-x grid-padding-x" id="logos">
-          <div class="cell small-12 medium-6 small-text-center medium-text-right">
-            <a href="http://cd2h.org/"><img class="logo" src="/images/CD2H_logo.png"></a>
-          </div>
-          <div class="cell small-12 medium-6 small-text-center medium-text-left">
-            <a href="http://nucats.northwestern.edu/"><img class="logo" src="/images/CATS-gradient.png"></a>
-          </div>
-        </div>
-        <div class="grid-x grid-padding-x text-center">
-          <div class="cell small-12">
-            <p>
-              Competitions is powered by the Northwestern University Clinical and Translational Sciences Institute (<a href="http://nucats.northwestern.edu/">NUCATS</a>) and is supported in part by the National Institutes of Health<br>
-              (NCATS UL1TR001422 and U24TR002306)
-            </p>
-            </p>
-            <p><a href="mailto:competitions-cd2h@northwestern.edu">competitions-cd2h@northwestern.edu</a></p>
-          </div>
-        </div>
-      </footer>
     </div>
     </div>
   </body>

--- a/public/404.html
+++ b/public/404.html
@@ -7,11 +7,7 @@
       h1 { font-size: 2em; margin: 0.67em 0; }
       hr { box-sizing: content-box; height: 0; overflow: visible; }
       a { background-color: transparent; }
-      b, strong { font-weight: bolder; }
-      img { border-style: none; }
-      *, *::before, *::after { box-sizing: inherit; }
       body { margin: 0; padding: 0; background: #fefefe; font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-weight: normal; line-height: 1.5; color: #0a0a0a; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-      img { display: inline-block; vertical-align: middle; max-width: 100%; height: auto; -ms-interpolation-mode: bicubic; }
       .grid-container { padding-right: 0.625rem; padding-left: 0.625rem; max-width: 75rem; margin: 0 auto; }
       @media print, screen and (min-width: 40em) { .grid-container { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
       .grid-x { display: flex; flex-flow: row wrap; }
@@ -42,20 +38,6 @@
         .grid-margin-x > .medium-6 { width: calc(50% - 1.875rem); }
       }
       .grid-padding-x .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-padding-x .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
-      .grid-container:not(.full) > .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-container:not(.full) > .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
-      .grid-padding-x > .cell { padding-right: 0.625rem; padding-left: 0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-padding-x > .cell { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
-      .small-up-1 > .cell { width: 100%; }
-      @media print, screen and (min-width: 40em) { .medium-up-2 > .cell { width: 50%; } }
-      @media print, screen and (min-width: 64em) { .large-up-3 > .cell { width: 33.3333333333%; } }
-      .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.25rem); }
-      @media print, screen and (min-width: 40em) {
-        .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.875rem); }
-      }
-      @media print, screen and (min-width: 64em) { .grid-margin-x.large-up-3 > .cell { width: calc(33.3333333333% - 1.875rem); } }
-      .grid-margin-y { margin-top: -0.625rem; margin-bottom: -0.625rem; }
       @media print, screen and (min-width: 40em) { .grid-margin-y { margin-top: -0.9375rem; margin-bottom: -0.9375rem; } }
       .grid-margin-y > .cell { height: calc(100% - 1.25rem); margin-top: 0.625rem; margin-bottom: 0.625rem; }
       @media print, screen and (min-width: 40em) { .grid-margin-y > .cell { height: calc(100% - 1.875rem); margin-top: 0.9375rem; margin-bottom: 0.9375rem; } }
@@ -77,8 +59,6 @@
       div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; }
       p { margin-bottom: 1rem; font-size: inherit; line-height: 1.6; text-rendering: optimizeLegibility; }
       em, i { font-style: italic; line-height: inherit; }
-      strong, b { font-weight: bold; line-height: inherit; }
-      small { font-size: 80%; line-height: inherit; }
       h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 { font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-style: normal; font-weight: normal; color: inherit; text-rendering: optimizeLegibility; }
       h1 small, .h1 small, h2 small, .h2 small, h3 small, .h3 small, h4 small, .h4 small, h5 small, .h5 small, h6 small, .h6 small { line-height: 0; color: #cacaca; }
       h1, .h1 { font-size: 1.5rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
@@ -98,39 +78,7 @@
       a:hover, a:focus { color: #1468a0; }
       a img { border: 0; }
       hr { clear: both; max-width: 75rem; height: 0; margin: 1.25rem auto; border-top: 0; border-right: 0; border-bottom: 1px solid #cacaca; border-left: 0; }
-      ul, ol, dl { margin-bottom: 1rem; list-style-position: outside; line-height: 1.6; }
-      li { font-size: inherit; }
-      ul { margin-left: 1.25rem; list-style-type: disc; }
-      ol { margin-left: 1.25rem; }
-      ul ul, ol ul, ul ol, ol ol { margin-left: 1.25rem; margin-bottom: 0; }
-      .subheader { margin-top: 0.2rem; margin-bottom: 0.5rem; font-weight: normal; line-height: 1.4; color: #8a8a8a; }
-      ul.no-bullet, ol.no-bullet { margin-left: 0; list-style: none; }
       .text-center { text-align: center; }
-      @media print, screen and (min-width: 40em) {
-        .medium-text-left { text-align: left; }
-        .medium-text-right { text-align: right; }
-        .medium-text-center { text-align: center; }
-        .medium-text-justify { text-align: justify; }
-      }
-      .menu { padding: 0; margin: 0; list-style: none; position: relative; display: flex; flex-wrap: wrap; }
-      .menu a { line-height: 1; text-decoration: none; display: block; padding: 0.7rem 1rem; }
-      .menu a { margin-bottom: 0; }
-      .top-bar { display: flex; flex-wrap: nowrap; justify-content: space-between; align-items: center; padding: 0.5rem; flex-wrap: wrap; }
-      .top-bar, .top-bar ul { background-color: #e6e6e6; }
-      .top-bar .top-bar-left, .top-bar .top-bar-right { flex: 0 0 100%; max-width: 100%; }
-      @media print, screen and (min-width: 40em) {
-        .top-bar { flex-wrap: nowrap; }
-        .top-bar .top-bar-left { flex: 1 1 auto; margin-right: auto; }
-        .top-bar .top-bar-right { flex: 0 1 auto; margin-left: auto; }
-      }
-      @media screen and (max-width: 63.99875em) {
-        .top-bar.stacked-for-medium { flex-wrap: wrap; }
-        .top-bar.stacked-for-medium .top-bar-left,   .top-bar.stacked-for-medium .top-bar-right { flex: 0 0 100%; max-width: 100%; }
-      }
-      .top-bar-left, .top-bar-right { flex: 0 0 auto; }
-      .home { font-weight: bold; }
-      .grid-container footer { background-color: #E6E6E6; color: #555; font-size: .85em; margin-top: 1.5em; padding: 1em; width: 100%; }
-      #logos .cell { padding: 1em 2em; }
     </style>
   </head>
   <body>

--- a/public/422.html
+++ b/public/422.html
@@ -2,16 +2,12 @@
   <head>
     <title>The change you wanted was rejected (422)</title>
     <style>
-      html { box-sizing: border-box; font-size: 100%; line-height: 1.15; -webkit-text-size-adjust: 100%; }
+ html { box-sizing: border-box; font-size: 100%; line-height: 1.15; -webkit-text-size-adjust: 100%; }
       body { margin: 0; }
       h1 { font-size: 2em; margin: 0.67em 0; }
       hr { box-sizing: content-box; height: 0; overflow: visible; }
       a { background-color: transparent; }
-      b, strong { font-weight: bolder; }
-      img { border-style: none; }
-      *, *::before, *::after { box-sizing: inherit; }
       body { margin: 0; padding: 0; background: #fefefe; font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-weight: normal; line-height: 1.5; color: #0a0a0a; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-      img { display: inline-block; vertical-align: middle; max-width: 100%; height: auto; -ms-interpolation-mode: bicubic; }
       .grid-container { padding-right: 0.625rem; padding-left: 0.625rem; max-width: 75rem; margin: 0 auto; }
       @media print, screen and (min-width: 40em) { .grid-container { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
       .grid-x { display: flex; flex-flow: row wrap; }
@@ -42,20 +38,6 @@
         .grid-margin-x > .medium-6 { width: calc(50% - 1.875rem); }
       }
       .grid-padding-x .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-padding-x .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
-      .grid-container:not(.full) > .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-container:not(.full) > .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
-      .grid-padding-x > .cell { padding-right: 0.625rem; padding-left: 0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-padding-x > .cell { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
-      .small-up-1 > .cell { width: 100%; }
-      @media print, screen and (min-width: 40em) { .medium-up-2 > .cell { width: 50%; } }
-      @media print, screen and (min-width: 64em) { .large-up-3 > .cell { width: 33.3333333333%; } }
-      .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.25rem); }
-      @media print, screen and (min-width: 40em) {
-        .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.875rem); }
-      }
-      @media print, screen and (min-width: 64em) { .grid-margin-x.large-up-3 > .cell { width: calc(33.3333333333% - 1.875rem); } }
-      .grid-margin-y { margin-top: -0.625rem; margin-bottom: -0.625rem; }
       @media print, screen and (min-width: 40em) { .grid-margin-y { margin-top: -0.9375rem; margin-bottom: -0.9375rem; } }
       .grid-margin-y > .cell { height: calc(100% - 1.25rem); margin-top: 0.625rem; margin-bottom: 0.625rem; }
       @media print, screen and (min-width: 40em) { .grid-margin-y > .cell { height: calc(100% - 1.875rem); margin-top: 0.9375rem; margin-bottom: 0.9375rem; } }
@@ -77,8 +59,6 @@
       div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; }
       p { margin-bottom: 1rem; font-size: inherit; line-height: 1.6; text-rendering: optimizeLegibility; }
       em, i { font-style: italic; line-height: inherit; }
-      strong, b { font-weight: bold; line-height: inherit; }
-      small { font-size: 80%; line-height: inherit; }
       h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 { font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-style: normal; font-weight: normal; color: inherit; text-rendering: optimizeLegibility; }
       h1 small, .h1 small, h2 small, .h2 small, h3 small, .h3 small, h4 small, .h4 small, h5 small, .h5 small, h6 small, .h6 small { line-height: 0; color: #cacaca; }
       h1, .h1 { font-size: 1.5rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
@@ -98,39 +78,7 @@
       a:hover, a:focus { color: #1468a0; }
       a img { border: 0; }
       hr { clear: both; max-width: 75rem; height: 0; margin: 1.25rem auto; border-top: 0; border-right: 0; border-bottom: 1px solid #cacaca; border-left: 0; }
-      ul, ol, dl { margin-bottom: 1rem; list-style-position: outside; line-height: 1.6; }
-      li { font-size: inherit; }
-      ul { margin-left: 1.25rem; list-style-type: disc; }
-      ol { margin-left: 1.25rem; }
-      ul ul, ol ul, ul ol, ol ol { margin-left: 1.25rem; margin-bottom: 0; }
-      .subheader { margin-top: 0.2rem; margin-bottom: 0.5rem; font-weight: normal; line-height: 1.4; color: #8a8a8a; }
-      ul.no-bullet, ol.no-bullet { margin-left: 0; list-style: none; }
       .text-center { text-align: center; }
-      @media print, screen and (min-width: 40em) {
-        .medium-text-left { text-align: left; }
-        .medium-text-right { text-align: right; }
-        .medium-text-center { text-align: center; }
-        .medium-text-justify { text-align: justify; }
-      }
-      .menu { padding: 0; margin: 0; list-style: none; position: relative; display: flex; flex-wrap: wrap; }
-      .menu a { line-height: 1; text-decoration: none; display: block; padding: 0.7rem 1rem; }
-      .menu a { margin-bottom: 0; }
-      .top-bar { display: flex; flex-wrap: nowrap; justify-content: space-between; align-items: center; padding: 0.5rem; flex-wrap: wrap; }
-      .top-bar, .top-bar ul { background-color: #e6e6e6; }
-      .top-bar .top-bar-left, .top-bar .top-bar-right { flex: 0 0 100%; max-width: 100%; }
-      @media print, screen and (min-width: 40em) {
-        .top-bar { flex-wrap: nowrap; }
-        .top-bar .top-bar-left { flex: 1 1 auto; margin-right: auto; }
-        .top-bar .top-bar-right { flex: 0 1 auto; margin-left: auto; }
-      }
-      @media screen and (max-width: 63.99875em) {
-        .top-bar.stacked-for-medium { flex-wrap: wrap; }
-        .top-bar.stacked-for-medium .top-bar-left,   .top-bar.stacked-for-medium .top-bar-right { flex: 0 0 100%; max-width: 100%; }
-      }
-      .top-bar-left, .top-bar-right { flex: 0 0 auto; }
-      .home { font-weight: bold; }
-      .grid-container footer { background-color: #E6E6E6; color: #555; font-size: .85em; margin-top: 1.5em; padding: 1em; width: 100%; }
-      #logos .cell { padding: 1em 2em; }
     </style>
   </head>
   <body>

--- a/public/422.html
+++ b/public/422.html
@@ -1,67 +1,161 @@
-<!DOCTYPE html>
 <html>
-<head>
-  <title>The change you wanted was rejected (422)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <div>
-      <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
+  <head>
+    <title>The change you wanted was rejected (422)</title>
+    <style>
+      html { box-sizing: border-box; font-size: 100%; line-height: 1.15; -webkit-text-size-adjust: 100%; }
+      body { margin: 0; }
+      h1 { font-size: 2em; margin: 0.67em 0; }
+      hr { box-sizing: content-box; height: 0; overflow: visible; }
+      a { background-color: transparent; }
+      b, strong { font-weight: bolder; }
+      img { border-style: none; }
+      *, *::before, *::after { box-sizing: inherit; }
+      body { margin: 0; padding: 0; background: #fefefe; font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-weight: normal; line-height: 1.5; color: #0a0a0a; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+      img { display: inline-block; vertical-align: middle; max-width: 100%; height: auto; -ms-interpolation-mode: bicubic; }
+      .grid-container { padding-right: 0.625rem; padding-left: 0.625rem; max-width: 75rem; margin: 0 auto; }
+      @media print, screen and (min-width: 40em) { .grid-container { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
+      .grid-x { display: flex; flex-flow: row wrap; }
+      .cell { flex: 0 0 auto; min-height: 0px; min-width: 0px; width: 100%; }
+      .grid-x > .small-10, .grid-x > .small-11, .grid-x > .small-12 { flex-basis: auto; }
+      @media print, screen and (min-width: 40em) { .grid-x > .medium-6 { flex-basis: auto; } }
+      .grid-x > .small-10, .grid-x > .small-11, .grid-x > .small-12 { flex: 0 0 auto; }
+      .grid-x > .small-10 { width: 83.3333333333%; }
+      .grid-x > .small-11 { width: 91.6666666667%; }
+      .grid-x > .small-12 { width: 100%; }
+      @media print, screen and (min-width: 40em) {
+        .grid-x > .medium-6 { flex: 0 0 auto; }
+        .grid-x > .medium-6 { width: 50%; }
+      }
+      .grid-margin-x:not(.grid-x) > .cell { width: auto; }
+      .grid-margin-y:not(.grid-y) > .cell { height: auto; }
+      .grid-margin-x { margin-left: -0.625rem; margin-right: -0.625rem; }
+      @media print, screen and (min-width: 40em) { . { margin-left: -0.9375rem; margin-right: -0.9375rem; } }
+      .grid-margin-x > .cell { width: calc(100% - 1.25rem); margin-left: 0.625rem; margin-right: 0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-margin-x > .cell { width: calc(100% - 1.875rem); margin-left: 0.9375rem; margin-right: 0.9375rem; } }
+      .grid-margin-x > .small-10 { width: calc(83.3333333333% - 1.25rem); }
+      .grid-margin-x > .small-11 { width: calc(91.6666666667% - 1.25rem); }
+      .grid-margin-x > .small-12 { width: calc(100% - 1.25rem); }
+      @media print, screen and (min-width: 40em) {
+        .grid-margin-x > .small-10 { width: calc(83.3333333333% - 1.875rem); }
+        .grid-margin-x > .small-11 { width: calc(91.6666666667% - 1.875rem); }
+        .grid-margin-x > .small-12 { width: calc(100% - 1.875rem); }
+        .grid-margin-x > .medium-6 { width: calc(50% - 1.875rem); }
+      }
+      .grid-padding-x .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-padding-x .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
+      .grid-container:not(.full) > .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-container:not(.full) > .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
+      .grid-padding-x > .cell { padding-right: 0.625rem; padding-left: 0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-padding-x > .cell { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
+      .small-up-1 > .cell { width: 100%; }
+      @media print, screen and (min-width: 40em) { .medium-up-2 > .cell { width: 50%; } }
+      @media print, screen and (min-width: 64em) { .large-up-3 > .cell { width: 33.3333333333%; } }
+      .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.25rem); }
+      @media print, screen and (min-width: 40em) {
+        .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.875rem); }
+      }
+      @media print, screen and (min-width: 64em) { .grid-margin-x.large-up-3 > .cell { width: calc(33.3333333333% - 1.875rem); } }
+      .grid-margin-y { margin-top: -0.625rem; margin-bottom: -0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-margin-y { margin-top: -0.9375rem; margin-bottom: -0.9375rem; } }
+      .grid-margin-y > .cell { height: calc(100% - 1.25rem); margin-top: 0.625rem; margin-bottom: 0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-margin-y > .cell { height: calc(100% - 1.875rem); margin-top: 0.9375rem; margin-bottom: 0.9375rem; } }
+      .grid-margin-y > .small-10 { height: calc(83.3333333333% - 1.25rem); }
+      .grid-margin-y > .small-11 { height: calc(91.6666666667% - 1.25rem); }
+      .grid-margin-y > .small-12 { height: calc(100% - 1.25rem); }
+      @media print, screen and (min-width: 40em) {
+        .grid-margin-y > .small-10 { height: calc(83.3333333333% - 1.875rem); }
+        .grid-margin-y > .small-11 { height: calc(91.6666666667% - 1.875rem); }
+        .grid-margin-y > .small-12 { height: calc(100% - 1.875rem); }
+        .grid-margin-y > .medium-6 { height: calc(50% - 1.875rem); }
+      }
+      @media print, screen and (min-width: 40em) { .medium-6 { width: 50%; } }
+      .small-10 { flex: 0 0 83.3333333333%; max-width: 83.3333333333%; }
+      .small-up-1 { flex-wrap: wrap; }
+      .align-center { justify-content: center; }
+      .align-justify { justify-content: space-between; }
+      .align-center-middle { justify-content: center; align-items: center; align-content: center; }
+      div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; }
+      p { margin-bottom: 1rem; font-size: inherit; line-height: 1.6; text-rendering: optimizeLegibility; }
+      em, i { font-style: italic; line-height: inherit; }
+      strong, b { font-weight: bold; line-height: inherit; }
+      small { font-size: 80%; line-height: inherit; }
+      h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 { font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-style: normal; font-weight: normal; color: inherit; text-rendering: optimizeLegibility; }
+      h1 small, .h1 small, h2 small, .h2 small, h3 small, .h3 small, h4 small, .h4 small, h5 small, .h5 small, h6 small, .h6 small { line-height: 0; color: #cacaca; }
+      h1, .h1 { font-size: 1.5rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h2, .h2 { font-size: 1.25rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h3, .h3 { font-size: 1.1875rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h4, .h4 { font-size: 1.125rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h5, .h5 { font-size: 1.0625rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h6, .h6 { font-size: 1rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      @media print, screen and (min-width: 40em) { h1, .h1 { font-size: 3rem; }
+        h2, .h2 { font-size: 2.5rem; }
+        h3, .h3 { font-size: 1.9375rem; }
+        h4, .h4 { font-size: 1.5625rem; }
+        h5, .h5 { font-size: 1.25rem; }
+        h6, .h6 { font-size: 1rem; }
+      }
+      a { line-height: inherit; color: #1779ba; text-decoration: none; cursor: pointer; }
+      a:hover, a:focus { color: #1468a0; }
+      a img { border: 0; }
+      hr { clear: both; max-width: 75rem; height: 0; margin: 1.25rem auto; border-top: 0; border-right: 0; border-bottom: 1px solid #cacaca; border-left: 0; }
+      ul, ol, dl { margin-bottom: 1rem; list-style-position: outside; line-height: 1.6; }
+      li { font-size: inherit; }
+      ul { margin-left: 1.25rem; list-style-type: disc; }
+      ol { margin-left: 1.25rem; }
+      ul ul, ol ul, ul ol, ol ol { margin-left: 1.25rem; margin-bottom: 0; }
+      .subheader { margin-top: 0.2rem; margin-bottom: 0.5rem; font-weight: normal; line-height: 1.4; color: #8a8a8a; }
+      ul.no-bullet, ol.no-bullet { margin-left: 0; list-style: none; }
+      .text-center { text-align: center; }
+      @media print, screen and (min-width: 40em) {
+        .medium-text-left { text-align: left; }
+        .medium-text-right { text-align: right; }
+        .medium-text-center { text-align: center; }
+        .medium-text-justify { text-align: justify; }
+      }
+      .menu { padding: 0; margin: 0; list-style: none; position: relative; display: flex; flex-wrap: wrap; }
+      .menu a { line-height: 1; text-decoration: none; display: block; padding: 0.7rem 1rem; }
+      .menu a { margin-bottom: 0; }
+      .top-bar { display: flex; flex-wrap: nowrap; justify-content: space-between; align-items: center; padding: 0.5rem; flex-wrap: wrap; }
+      .top-bar, .top-bar ul { background-color: #e6e6e6; }
+      .top-bar .top-bar-left, .top-bar .top-bar-right { flex: 0 0 100%; max-width: 100%; }
+      @media print, screen and (min-width: 40em) {
+        .top-bar { flex-wrap: nowrap; }
+        .top-bar .top-bar-left { flex: 1 1 auto; margin-right: auto; }
+        .top-bar .top-bar-right { flex: 0 1 auto; margin-left: auto; }
+      }
+      @media screen and (max-width: 63.99875em) {
+        .top-bar.stacked-for-medium { flex-wrap: wrap; }
+        .top-bar.stacked-for-medium .top-bar-left,   .top-bar.stacked-for-medium .top-bar-right { flex: 0 0 100%; max-width: 100%; }
+      }
+      .top-bar-left, .top-bar-right { flex: 0 0 auto; }
+      .home { font-weight: bold; }
+      .grid-container footer { background-color: #E6E6E6; color: #555; font-size: .85em; margin-top: 1.5em; padding: 1em; width: 100%; }
+      #logos .cell { padding: 1em 2em; }
+    </style>
+  </head>
+  <body>
+    <div class="grid-container">
+      <div class="grid-x grid-margin-x grid-margin-y">
+        <main class="cell" style="min-height: 30em;">
+          <div class="grid-x align-center-middle">
+            <div class="section-intro">
+              <h3 class="subheader text-align-center" style="margin-top: 2em;">
+                The change you wanted was rejected.
+              </h3>
+            </div>
+          </div>
+          <div class="grid-x grid-padding-x small-up-1 medium-up-2 large-up-3" id="public-grants">
+            <div class="small-12 text-center">
+              <h5><p>Maybe you tried to change something you didn't have access to.</p>
+                <p>If you are the application owner check the logs for more information.</p>
+                <p><a href="/">Try the homepage to see a list of current grants.</a></p>
+              </h5>
+            </div>
+          </div>
+        </main>
+      </div>
+      <div class="grid-x grid-margin-x grid-margin-y">
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+    </div>
+  </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -2,16 +2,12 @@
   <head>
     <title>We're sorry, but something went wrong (500)</title>
     <style>
-      html { box-sizing: border-box; font-size: 100%; line-height: 1.15; -webkit-text-size-adjust: 100%; }
+ html { box-sizing: border-box; font-size: 100%; line-height: 1.15; -webkit-text-size-adjust: 100%; }
       body { margin: 0; }
       h1 { font-size: 2em; margin: 0.67em 0; }
       hr { box-sizing: content-box; height: 0; overflow: visible; }
       a { background-color: transparent; }
-      b, strong { font-weight: bolder; }
-      img { border-style: none; }
-      *, *::before, *::after { box-sizing: inherit; }
       body { margin: 0; padding: 0; background: #fefefe; font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-weight: normal; line-height: 1.5; color: #0a0a0a; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-      img { display: inline-block; vertical-align: middle; max-width: 100%; height: auto; -ms-interpolation-mode: bicubic; }
       .grid-container { padding-right: 0.625rem; padding-left: 0.625rem; max-width: 75rem; margin: 0 auto; }
       @media print, screen and (min-width: 40em) { .grid-container { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
       .grid-x { display: flex; flex-flow: row wrap; }
@@ -42,20 +38,6 @@
         .grid-margin-x > .medium-6 { width: calc(50% - 1.875rem); }
       }
       .grid-padding-x .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-padding-x .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
-      .grid-container:not(.full) > .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-container:not(.full) > .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
-      .grid-padding-x > .cell { padding-right: 0.625rem; padding-left: 0.625rem; }
-      @media print, screen and (min-width: 40em) { .grid-padding-x > .cell { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
-      .small-up-1 > .cell { width: 100%; }
-      @media print, screen and (min-width: 40em) { .medium-up-2 > .cell { width: 50%; } }
-      @media print, screen and (min-width: 64em) { .large-up-3 > .cell { width: 33.3333333333%; } }
-      .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.25rem); }
-      @media print, screen and (min-width: 40em) {
-        .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.875rem); }
-      }
-      @media print, screen and (min-width: 64em) { .grid-margin-x.large-up-3 > .cell { width: calc(33.3333333333% - 1.875rem); } }
-      .grid-margin-y { margin-top: -0.625rem; margin-bottom: -0.625rem; }
       @media print, screen and (min-width: 40em) { .grid-margin-y { margin-top: -0.9375rem; margin-bottom: -0.9375rem; } }
       .grid-margin-y > .cell { height: calc(100% - 1.25rem); margin-top: 0.625rem; margin-bottom: 0.625rem; }
       @media print, screen and (min-width: 40em) { .grid-margin-y > .cell { height: calc(100% - 1.875rem); margin-top: 0.9375rem; margin-bottom: 0.9375rem; } }
@@ -77,8 +59,6 @@
       div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; }
       p { margin-bottom: 1rem; font-size: inherit; line-height: 1.6; text-rendering: optimizeLegibility; }
       em, i { font-style: italic; line-height: inherit; }
-      strong, b { font-weight: bold; line-height: inherit; }
-      small { font-size: 80%; line-height: inherit; }
       h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 { font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-style: normal; font-weight: normal; color: inherit; text-rendering: optimizeLegibility; }
       h1 small, .h1 small, h2 small, .h2 small, h3 small, .h3 small, h4 small, .h4 small, h5 small, .h5 small, h6 small, .h6 small { line-height: 0; color: #cacaca; }
       h1, .h1 { font-size: 1.5rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
@@ -98,39 +78,7 @@
       a:hover, a:focus { color: #1468a0; }
       a img { border: 0; }
       hr { clear: both; max-width: 75rem; height: 0; margin: 1.25rem auto; border-top: 0; border-right: 0; border-bottom: 1px solid #cacaca; border-left: 0; }
-      ul, ol, dl { margin-bottom: 1rem; list-style-position: outside; line-height: 1.6; }
-      li { font-size: inherit; }
-      ul { margin-left: 1.25rem; list-style-type: disc; }
-      ol { margin-left: 1.25rem; }
-      ul ul, ol ul, ul ol, ol ol { margin-left: 1.25rem; margin-bottom: 0; }
-      .subheader { margin-top: 0.2rem; margin-bottom: 0.5rem; font-weight: normal; line-height: 1.4; color: #8a8a8a; }
-      ul.no-bullet, ol.no-bullet { margin-left: 0; list-style: none; }
       .text-center { text-align: center; }
-      @media print, screen and (min-width: 40em) {
-        .medium-text-left { text-align: left; }
-        .medium-text-right { text-align: right; }
-        .medium-text-center { text-align: center; }
-        .medium-text-justify { text-align: justify; }
-      }
-      .menu { padding: 0; margin: 0; list-style: none; position: relative; display: flex; flex-wrap: wrap; }
-      .menu a { line-height: 1; text-decoration: none; display: block; padding: 0.7rem 1rem; }
-      .menu a { margin-bottom: 0; }
-      .top-bar { display: flex; flex-wrap: nowrap; justify-content: space-between; align-items: center; padding: 0.5rem; flex-wrap: wrap; }
-      .top-bar, .top-bar ul { background-color: #e6e6e6; }
-      .top-bar .top-bar-left, .top-bar .top-bar-right { flex: 0 0 100%; max-width: 100%; }
-      @media print, screen and (min-width: 40em) {
-        .top-bar { flex-wrap: nowrap; }
-        .top-bar .top-bar-left { flex: 1 1 auto; margin-right: auto; }
-        .top-bar .top-bar-right { flex: 0 1 auto; margin-left: auto; }
-      }
-      @media screen and (max-width: 63.99875em) {
-        .top-bar.stacked-for-medium { flex-wrap: wrap; }
-        .top-bar.stacked-for-medium .top-bar-left,   .top-bar.stacked-for-medium .top-bar-right { flex: 0 0 100%; max-width: 100%; }
-      }
-      .top-bar-left, .top-bar-right { flex: 0 0 auto; }
-      .home { font-weight: bold; }
-      .grid-container footer { background-color: #E6E6E6; color: #555; font-size: .85em; margin-top: 1.5em; padding: 1em; width: 100%; }
-      #logos .cell { padding: 1em 2em; }
     </style>
   </head>
   <body>

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,160 @@
-<!DOCTYPE html>
 <html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
+  <head>
+    <title>We're sorry, but something went wrong (500)</title>
+    <style>
+      html { box-sizing: border-box; font-size: 100%; line-height: 1.15; -webkit-text-size-adjust: 100%; }
+      body { margin: 0; }
+      h1 { font-size: 2em; margin: 0.67em 0; }
+      hr { box-sizing: content-box; height: 0; overflow: visible; }
+      a { background-color: transparent; }
+      b, strong { font-weight: bolder; }
+      img { border-style: none; }
+      *, *::before, *::after { box-sizing: inherit; }
+      body { margin: 0; padding: 0; background: #fefefe; font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-weight: normal; line-height: 1.5; color: #0a0a0a; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+      img { display: inline-block; vertical-align: middle; max-width: 100%; height: auto; -ms-interpolation-mode: bicubic; }
+      .grid-container { padding-right: 0.625rem; padding-left: 0.625rem; max-width: 75rem; margin: 0 auto; }
+      @media print, screen and (min-width: 40em) { .grid-container { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
+      .grid-x { display: flex; flex-flow: row wrap; }
+      .cell { flex: 0 0 auto; min-height: 0px; min-width: 0px; width: 100%; }
+      .grid-x > .small-10, .grid-x > .small-11, .grid-x > .small-12 { flex-basis: auto; }
+      @media print, screen and (min-width: 40em) { .grid-x > .medium-6 { flex-basis: auto; } }
+      .grid-x > .small-10, .grid-x > .small-11, .grid-x > .small-12 { flex: 0 0 auto; }
+      .grid-x > .small-10 { width: 83.3333333333%; }
+      .grid-x > .small-11 { width: 91.6666666667%; }
+      .grid-x > .small-12 { width: 100%; }
+      @media print, screen and (min-width: 40em) {
+        .grid-x > .medium-6 { flex: 0 0 auto; }
+        .grid-x > .medium-6 { width: 50%; }
+      }
+      .grid-margin-x:not(.grid-x) > .cell { width: auto; }
+      .grid-margin-y:not(.grid-y) > .cell { height: auto; }
+      .grid-margin-x { margin-left: -0.625rem; margin-right: -0.625rem; }
+      @media print, screen and (min-width: 40em) { . { margin-left: -0.9375rem; margin-right: -0.9375rem; } }
+      .grid-margin-x > .cell { width: calc(100% - 1.25rem); margin-left: 0.625rem; margin-right: 0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-margin-x > .cell { width: calc(100% - 1.875rem); margin-left: 0.9375rem; margin-right: 0.9375rem; } }
+      .grid-margin-x > .small-10 { width: calc(83.3333333333% - 1.25rem); }
+      .grid-margin-x > .small-11 { width: calc(91.6666666667% - 1.25rem); }
+      .grid-margin-x > .small-12 { width: calc(100% - 1.25rem); }
+      @media print, screen and (min-width: 40em) {
+        .grid-margin-x > .small-10 { width: calc(83.3333333333% - 1.875rem); }
+        .grid-margin-x > .small-11 { width: calc(91.6666666667% - 1.875rem); }
+        .grid-margin-x > .small-12 { width: calc(100% - 1.875rem); }
+        .grid-margin-x > .medium-6 { width: calc(50% - 1.875rem); }
+      }
+      .grid-padding-x .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-padding-x .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
+      .grid-container:not(.full) > .grid-padding-x { margin-right: -0.625rem; margin-left: -0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-container:not(.full) > .grid-padding-x { margin-right: -0.9375rem; margin-left: -0.9375rem; } }
+      .grid-padding-x > .cell { padding-right: 0.625rem; padding-left: 0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-padding-x > .cell { padding-right: 0.9375rem; padding-left: 0.9375rem; } }
+      .small-up-1 > .cell { width: 100%; }
+      @media print, screen and (min-width: 40em) { .medium-up-2 > .cell { width: 50%; } }
+      @media print, screen and (min-width: 64em) { .large-up-3 > .cell { width: 33.3333333333%; } }
+      .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.25rem); }
+      @media print, screen and (min-width: 40em) {
+        .grid-margin-x.small-up-1 > .cell { width: calc(100% - 1.875rem); }
+      }
+      @media print, screen and (min-width: 64em) { .grid-margin-x.large-up-3 > .cell { width: calc(33.3333333333% - 1.875rem); } }
+      .grid-margin-y { margin-top: -0.625rem; margin-bottom: -0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-margin-y { margin-top: -0.9375rem; margin-bottom: -0.9375rem; } }
+      .grid-margin-y > .cell { height: calc(100% - 1.25rem); margin-top: 0.625rem; margin-bottom: 0.625rem; }
+      @media print, screen and (min-width: 40em) { .grid-margin-y > .cell { height: calc(100% - 1.875rem); margin-top: 0.9375rem; margin-bottom: 0.9375rem; } }
+      .grid-margin-y > .small-10 { height: calc(83.3333333333% - 1.25rem); }
+      .grid-margin-y > .small-11 { height: calc(91.6666666667% - 1.25rem); }
+      .grid-margin-y > .small-12 { height: calc(100% - 1.25rem); }
+      @media print, screen and (min-width: 40em) {
+        .grid-margin-y > .small-10 { height: calc(83.3333333333% - 1.875rem); }
+        .grid-margin-y > .small-11 { height: calc(91.6666666667% - 1.875rem); }
+        .grid-margin-y > .small-12 { height: calc(100% - 1.875rem); }
+        .grid-margin-y > .medium-6 { height: calc(50% - 1.875rem); }
+      }
+      @media print, screen and (min-width: 40em) { .medium-6 { width: 50%; } }
+      .small-10 { flex: 0 0 83.3333333333%; max-width: 83.3333333333%; }
+      .small-up-1 { flex-wrap: wrap; }
+      .align-center { justify-content: center; }
+      .align-justify { justify-content: space-between; }
+      .align-center-middle { justify-content: center; align-items: center; align-content: center; }
+      div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; }
+      p { margin-bottom: 1rem; font-size: inherit; line-height: 1.6; text-rendering: optimizeLegibility; }
+      em, i { font-style: italic; line-height: inherit; }
+      strong, b { font-weight: bold; line-height: inherit; }
+      small { font-size: 80%; line-height: inherit; }
+      h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 { font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif; font-style: normal; font-weight: normal; color: inherit; text-rendering: optimizeLegibility; }
+      h1 small, .h1 small, h2 small, .h2 small, h3 small, .h3 small, h4 small, .h4 small, h5 small, .h5 small, h6 small, .h6 small { line-height: 0; color: #cacaca; }
+      h1, .h1 { font-size: 1.5rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h2, .h2 { font-size: 1.25rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h3, .h3 { font-size: 1.1875rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h4, .h4 { font-size: 1.125rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h5, .h5 { font-size: 1.0625rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      h6, .h6 { font-size: 1rem; line-height: 1.4; margin-top: 0; margin-bottom: 0.5rem; }
+      @media print, screen and (min-width: 40em) { h1, .h1 { font-size: 3rem; }
+        h2, .h2 { font-size: 2.5rem; }
+        h3, .h3 { font-size: 1.9375rem; }
+        h4, .h4 { font-size: 1.5625rem; }
+        h5, .h5 { font-size: 1.25rem; }
+        h6, .h6 { font-size: 1rem; }
+      }
+      a { line-height: inherit; color: #1779ba; text-decoration: none; cursor: pointer; }
+      a:hover, a:focus { color: #1468a0; }
+      a img { border: 0; }
+      hr { clear: both; max-width: 75rem; height: 0; margin: 1.25rem auto; border-top: 0; border-right: 0; border-bottom: 1px solid #cacaca; border-left: 0; }
+      ul, ol, dl { margin-bottom: 1rem; list-style-position: outside; line-height: 1.6; }
+      li { font-size: inherit; }
+      ul { margin-left: 1.25rem; list-style-type: disc; }
+      ol { margin-left: 1.25rem; }
+      ul ul, ol ul, ul ol, ol ol { margin-left: 1.25rem; margin-bottom: 0; }
+      .subheader { margin-top: 0.2rem; margin-bottom: 0.5rem; font-weight: normal; line-height: 1.4; color: #8a8a8a; }
+      ul.no-bullet, ol.no-bullet { margin-left: 0; list-style: none; }
+      .text-center { text-align: center; }
+      @media print, screen and (min-width: 40em) {
+        .medium-text-left { text-align: left; }
+        .medium-text-right { text-align: right; }
+        .medium-text-center { text-align: center; }
+        .medium-text-justify { text-align: justify; }
+      }
+      .menu { padding: 0; margin: 0; list-style: none; position: relative; display: flex; flex-wrap: wrap; }
+      .menu a { line-height: 1; text-decoration: none; display: block; padding: 0.7rem 1rem; }
+      .menu a { margin-bottom: 0; }
+      .top-bar { display: flex; flex-wrap: nowrap; justify-content: space-between; align-items: center; padding: 0.5rem; flex-wrap: wrap; }
+      .top-bar, .top-bar ul { background-color: #e6e6e6; }
+      .top-bar .top-bar-left, .top-bar .top-bar-right { flex: 0 0 100%; max-width: 100%; }
+      @media print, screen and (min-width: 40em) {
+        .top-bar { flex-wrap: nowrap; }
+        .top-bar .top-bar-left { flex: 1 1 auto; margin-right: auto; }
+        .top-bar .top-bar-right { flex: 0 1 auto; margin-left: auto; }
+      }
+      @media screen and (max-width: 63.99875em) {
+        .top-bar.stacked-for-medium { flex-wrap: wrap; }
+        .top-bar.stacked-for-medium .top-bar-left,   .top-bar.stacked-for-medium .top-bar-right { flex: 0 0 100%; max-width: 100%; }
+      }
+      .top-bar-left, .top-bar-right { flex: 0 0 auto; }
+      .home { font-weight: bold; }
+      .grid-container footer { background-color: #E6E6E6; color: #555; font-size: .85em; margin-top: 1.5em; padding: 1em; width: 100%; }
+      #logos .cell { padding: 1em 2em; }
+    </style>
+  </head>
+  <body>
+    <div class="grid-container">
+      <div class="grid-x grid-margin-x grid-margin-y">
+        <main class="cell" style="min-height: 30em;">
+          <div class="grid-x align-center-middle">
+            <div class="section-intro">
+              <h3 class="subheader text-align-center" style="margin-top: 2em;">
+                We're sorry, but something went wrong.
+              </h3>
+            </div>
+          </div>
+          <div class="grid-x grid-padding-x small-up-1 medium-up-2 large-up-3" id="public-grants">
+            <div class="small-12 text-center">
+              <h5><p>If you are the application owner check the logs for more information.</p>
+                <p><a href="/">Try the homepage to see a list of current grants.</a></p>
+              </h5>
+            </div>
+          </div>
+        </main>
+      </div>
+      <div class="grid-x grid-margin-x grid-margin-y">
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
closes #494 .

This takes out specifics like email and footer from the error pages to prepare for open-sourcing. 