### PR TITLE
Clarify delete confirm dialogs

### DIFF
--- a/app/assets/javascripts/form_builder_survey.js
+++ b/app/assets/javascripts/form_builder_survey.js
@@ -25,6 +25,10 @@
       // that.copy_in_follow_up_dependency(this);
     });
 
+    $(document).on('nested:fieldRemoved', function(event) {
+      confirm('Please submit the form to confirm your changes.');
+    });
+
     //see https://github.com/ryanb/nested_form/blob/0.3.2/README.md#javascript-events
     $(document).on('nested:fieldAdded', function(event){
       $("fieldset.form_builder_question_fieldset", event.field).each(function(){

--- a/app/assets/stylesheets/grant_submission_form.scss
+++ b/app/assets/stylesheets/grant_submission_form.scss
@@ -1,7 +1,9 @@
 main.forms {
   form.edit_grant_submission_form {
-    a.button {
-      margin: 0.25em 0.5em;
+    fieldset {
+      a.button {
+        margin: 0.25em 0.5em;
+      }
     }
     fieldset.fieldset {
       legend {

--- a/app/controllers/grant_submissions/forms_controller.rb
+++ b/app/controllers/grant_submissions/forms_controller.rb
@@ -6,6 +6,9 @@ module GrantSubmissions
     def edit
       @form = GrantSubmission::Form.includes(:sections=>{:questions=>[:multiple_choice_options]}).find(params[:id])
       authorize @form
+      if params[:cancelled]
+        flash[:warning] = 'All changes were discarded.'
+      end
     end
 
     def update
@@ -31,6 +34,7 @@ module GrantSubmissions
 
     def form_params
       params.require(:grant_submission_form).permit(
+          :cancelled,
           :submission_instructions,
           sections_attributes: [
             :id,

--- a/app/views/banners/_form.html.haml
+++ b/app/views/banners/_form.html.haml
@@ -27,4 +27,4 @@
     - else
       = f.submit 'Update', class: 'button'
       = link_to 'Cancel', banner, class: 'button secondary clear'
-      = link_to 'Delete', banner, method: :destroy, data: { confirm: 'Are you sure?'}, class: 'button alert clear'
+      = link_to 'Delete', banner, method: :destroy, data: { confirm: 'Are you sure you want to delete this banner entirely? To take it down without deleting it, uncheck the Visible box.'}, class: 'button alert clear'

--- a/app/views/grant_permissions/_admin_links.html.haml
+++ b/app/views/grant_permissions/_admin_links.html.haml
@@ -1,3 +1,3 @@
 %ul.menu.simple
   %li= link_to 'Edit', edit_grant_grant_permission_path(grant, grant_permission)
-  %li= link_to 'Delete', grant_grant_permission_path(grant, grant_permission), method: :delete, data: { confirm: 'Are you sure?' }
+  %li= link_to 'Delete', grant_grant_permission_path(grant, grant_permission), method: :delete, data: { confirm: "Are you sure you want to remove #{grant_permission_user_name} name from this grant?" }

--- a/app/views/grant_permissions/index.html.haml
+++ b/app/views/grant_permissions/index.html.haml
@@ -44,10 +44,11 @@
 
       %tbody
         - @grant_permissions.each do |grant_permission|
+          - grant_permission_user_name = full_name(grant_permission.user)
           %tr
             %td
-              = full_name(grant_permission.user)
+              = grant_permission_user_name
             %td
               = grant_permission.role.capitalize
             %td
-              = render partial: "#{current_user.get_role_by_grant(grant: @grant)}_links", locals: { grant_permission: grant_permission, grant: @grant }
+              = render partial: "#{current_user.get_role_by_grant(grant: @grant)}_links", locals: { grant_permission: grant_permission, grant: @grant, grant_permission_user_name: grant_permission_user_name }

--- a/app/views/grant_submissions/forms/_form.html.haml
+++ b/app/views/grant_submissions/forms/_form.html.haml
@@ -37,6 +37,7 @@
     .actions
       %hr
       = f.submit 'Save', class: 'button' unless disable_fields
+      = link_to 'Cancel', edit_grant_form_path(@grant, @form, cancelled: true), class: 'button secondary clear', title: 'Discard your changes'
 
 - if disable_fields
   :javascript

--- a/app/views/grants/_form.html.haml
+++ b/app/views/grants/_form.html.haml
@@ -83,7 +83,7 @@
       - else
         = f.submit 'Update', class: 'button'
         = link_to 'Cancel', grant, class: 'button secondary clear'
-      = link_to 'Delete', grant, method: :delete, disabled: disable_fields, data: { confirm: 'Are you sure?'}, class: 'button alert clear'
+      = link_to 'Delete', grant, method: :delete, disabled: disable_fields, data: { confirm: 'Are you sure you want to delete this grant entirely?'}, class: 'button alert clear'
 
 :javascript
   $(function() {

--- a/lib/grant_submission_form_builder.rb
+++ b/lib/grant_submission_form_builder.rb
@@ -64,7 +64,6 @@ class GrantSubmissionFormBuilder < ActionView::Helpers::FormBuilder
   def grant_disable_input?
     if options[:parent_builder]
       options[:parent_builder].instance_of?(self.class) ? options[:parent_builder].grant_disable_input? : !options[:parent_builder].object.available?
-      # options[:parent_builder].instance_of?(GrantFormBuilder) ? options[:parent_builder].grant_disable_input? : !options[:parent_builder].object.available?
     else
       read_only || !object.available?
     end

--- a/spec/system/grant_submissions/grant_submission_forms_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_forms_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe 'GrantSubmission::Forms', type: :system do
         scenario 'display_order is updated on delete' do
           original_section = @draft_grant.form.sections.first
           expect(original_section.display_order).to be 1
-          find('.delete-section').click
+          accept_alert do
+            find('.delete-section').click
+          end
           click_link add_section_text
           new_section_text = Faker::Lorem.sentence
           find_field('Title', with: '').set(new_section_text)
@@ -66,7 +68,9 @@ RSpec.describe 'GrantSubmission::Forms', type: :system do
           click_button 'Save'
           original_section_section = @draft_grant.form.sections.second
           original_last_section    = @draft_grant.form.sections.last
-          page.find("#delete-section-#{original_section_section.id}").click
+          accept_alert do
+            page.find("#delete-section-#{original_section_section.id}").click
+          end
           click_button 'Save'
           expect(@draft_grant.form.sections.count).to be 2
           expect(GrantSubmission::Section.find(original_first_section.id).display_order).to be 1
@@ -76,7 +80,9 @@ RSpec.describe 'GrantSubmission::Forms', type: :system do
 
       context 'question' do
         scenario 'display_order is updated on delete' do
-          page.find("#delete-question-#{@original_first_question.id}").click
+          accept_alert do
+            page.find("#delete-question-#{@original_first_question.id}").click
+          end
           click_button 'Save'
           expect(@draft_grant.questions.all?{ |q| q.display_order <= 2 })
           expect(GrantSubmission::Question.find(@original_second_question.id).display_order).to be 1
@@ -86,7 +92,9 @@ RSpec.describe 'GrantSubmission::Forms', type: :system do
         scenario 'display_order is updated when question in middle of form is deleted' do
           expect(@original_first_question.display_order).to be 1
           expect(@original_third_question.display_order).to be 3
-          page.find("#delete-question-#{@original_second_question.id}").click
+          accept_alert do
+            page.find("#delete-question-#{@original_second_question.id}").click
+          end
           click_button 'Save'
           expect(@draft_grant.questions.all?{ |q| q.display_order <= 2 })
           expect(GrantSubmission::Question.find(@original_first_question.id).display_order).to be 1

--- a/spec/system/grant_submissions/grant_submission_multiple_choice_options_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_multiple_choice_options_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe 'GrantSubmission::MultipleChoiceOptions', type: :system do
     context 'edit' do
       scenario 'requires at least one option' do
         @grant.questions.where(response_type: 'pick_one').last.multiple_choice_options.count.times do
-          find('.delete-option', match: :first).click
+          accept_alert do
+            find('.delete-option', match: :first).click
+          end
         end
         click_button 'Save'
         expect(page).to have_text requires_option_text
@@ -30,7 +32,9 @@ RSpec.describe 'GrantSubmission::MultipleChoiceOptions', type: :system do
 
       scenario 'requires text' do
         @grant.questions.where(response_type: 'pick_one').last.multiple_choice_options.count.times do
-          find('.delete-option', match: :first).click
+          accept_alert do
+            find('.delete-option', match: :first).click
+          end
         end
         find('.add-option').click
         click_button 'Save'


### PR DESCRIPTION
Improve data-confirm dialogues for delete links. Add reminder to save submission form changes. 

Closes #578  