### PR TITLE
Task/manage reviewer invitations

### DIFF
--- a/app/controllers/grant_reviewers/invitations/reminders_controller.rb
+++ b/app/controllers/grant_reviewers/invitations/reminders_controller.rb
@@ -2,7 +2,6 @@ module GrantReviewers
   module Invitations
     class RemindersController < InvitationsController
       def index
-        authorize @grant, :edit?
         @open_invitations = GrantReviewer::Invitation
                               .with_inviter
                               .where(grant_id: @grant.id)
@@ -13,16 +12,33 @@ module GrantReviewers
         else
           flash[:warning] = 'There are no open reviewer invitations for this grant. No reminders have been sent'
         end
-        redirect_to grant_invitations_path(@grant)
+        redirect_back fallback_location: grant_invitations_path(@grant)
+      end
+
+      def show
+        invitation = GrantReviewer::Invitation.find(params[:id])
+
+        if invitation.present? && invitation.invitee.nil?
+          send_reminder_email(invitation)
+          flash[:success] = "A reminder has been sent to #{invitation.email}."
+        else
+          flash[:warning] = 'A reminder could not be sent to the selected email address.'
+        end
+
+        redirect_back fallback_location: grant_invitations_path(@grant)
       end
 
       private
 
       def send_reminder_emails
         @open_invitations.each do |invitation|
-          GrantReviewerInvitationMailer.reminder(invitation: invitation, grant: @grant).deliver_now
-          invitation.update(reminded_at: Time.now)
+          send_reminder_email(invitation)
         end
+      end
+
+      def send_reminder_email(invitation)
+        GrantReviewerInvitationMailer.reminder(invitation: invitation, grant: @grant).deliver_now
+        invitation.update(reminded_at: Time.now)
       end
     end
   end

--- a/app/models/grant_reviewer/invitation.rb
+++ b/app/models/grant_reviewer/invitation.rb
@@ -11,6 +11,8 @@ class GrantReviewer::Invitation < ApplicationRecord
 
   validates_presence_of   :email
   validates_uniqueness_of :email, scope: :grant, message: 'has already been invited.'
+  validates               :email, format: { with: Devise.email_regexp }
+
   validate :inviter_may_invite
 
   scope :with_inviter,-> { includes(:inviter) }

--- a/app/views/grant_reviewers/invitations/_invitation.html.haml
+++ b/app/views/grant_reviewers/invitations/_invitation.html.haml
@@ -7,3 +7,13 @@
     = (invitation.confirmed_at.nil?) ? '-' : time_tag(invitation.confirmed_at, invitation.confirmed_at.to_formatted_s(:default))
   %td.inviter
     = full_name(invitation.inviter)
+  %td.manage
+    - if invitation.confirmed_at.nil?
+      %ul.dropdown.menu{ data: { "dropdown-menu": '' } }
+        %li.text
+          = link_to 'Manage', '#', id: "manage-#{dom_id(invitation)}"
+          %ul.menu
+            %li
+              = link_to 'Send Reminder', grant_invitation_reminder_url(grant.id, invitation)
+              = link_to 'Delete', grant_invitation_path(grant.id, invitation), method: :delete, data: { confirm: 'This inviation will be deleted and the recipient will need to be invited again.' }
+

--- a/app/views/grant_reviewers/invitations/index.html.haml
+++ b/app/views/grant_reviewers/invitations/index.html.haml
@@ -31,9 +31,12 @@
             Actions:
           - if @has_open_invitations
             %li
-              = link_to 'Send Reminder to Invited Reviewers', grant_invitation_reminders_path(@grant)
+              = link_to 'Send Reminder to All Invited Reviewers', grant_invitation_reminders_path(@grant)
           %li
             = link_to 'Back to Reviewers', grant_reviewers_path(@grant)
+
+        %p
+          Individual reminders may also be sent to specific Invitations using the "Manage" links below.
 
   %table#grant-reviewer-invitations
     %thead
@@ -46,5 +49,7 @@
           Confirmed On
         %th
           Invited By
+        %th
+          Manage
     %tbody
-      = render partial: 'invitation', collection: @invitations, as: :invitation
+      = render partial: 'invitation', collection: @invitations, locals: { grant: @grant }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,12 @@ Rails.application.configure do
                                                port: COMPETITIONS_CONFIG[:default_url_options][:port] }
   config.action_mailer.delivery_method = COMPETITIONS_CONFIG[:mailer][:delivery_method].to_sym
   config.action_mailer.smtp_settings = Rails.application.secrets[:smtp_settings]
+
+  # Bullet
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.add_footer = true
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,11 +19,6 @@ Rails.application.configure do
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
-    # As part of ticket #235
-    #   Fix TypeError related to caching.
-    #   See: https://stackoverflow.com/a/7838450
-    config.cache_classes = true
-
     config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
@@ -60,6 +55,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.reload_classes_only_on_change = true
 
   # Time zone
   config.time_zone = 'Central Time (US & Canada)'
@@ -76,12 +72,4 @@ Rails.application.configure do
                                                port: COMPETITIONS_CONFIG[:default_url_options][:port] }
   config.action_mailer.delivery_method = COMPETITIONS_CONFIG[:mailer][:delivery_method].to_sym
   config.action_mailer.smtp_settings = Rails.application.secrets[:smtp_settings]
-
-  Bullet
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.bullet_logger = true
-    Bullet.console = true
-    Bullet.add_footer = true
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,9 +71,9 @@ Rails.application.routes.draw do
     resources :reviewers,         only: %i[index create destroy], controller: 'grant_reviewers' do
       collection do
         post      'invite',       to: 'grant_reviewers/invitations#create'
-        resources 'invitations',  only: %i[index update], controller: 'grant_reviewers/invitations' do
+        resources 'invitations',  only: %i[index update destroy], controller: 'grant_reviewers/invitations' do
           collection do
-            resources :reminders, only: :index, as: 'invitation_reminders', controller: 'grant_reviewers/invitations/reminders'
+            resources :reminders, only: %i[index show], as: 'invitation_reminders', controller: 'grant_reviewers/invitations/reminders'
           end
         end
       end

--- a/spec/models/grant_reviewer_invitation_spec.rb
+++ b/spec/models/grant_reviewer_invitation_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe GrantReviewer::Invitation, type: :model do
         expect(invitation.errors).to include(:inviter)
         expect(invitation.errors.full_messages).to include 'Inviter does not have permission on this grant.'
       end
+
+      it 'requires a valid email address' do
+        invitation.email = 'not an email address'
+        expect(invitation).not_to be_valid
+        expect(invitation.errors).to include(:email)
+        expect(invitation.errors.full_messages).to include 'Email is invalid'
+     end
     end
   end
 

--- a/spec/requests/grant_reviewer_requests/invitations_spec.rb
+++ b/spec/requests/grant_reviewer_requests/invitations_spec.rb
@@ -34,15 +34,31 @@ RSpec.describe 'grant_reviewer_invitation requests', type: :request do
       login_user inviter
     end
 
-    it 'sends reminder mail to the invitee' do
-      get(grant_invitation_reminders_path(grant))
-      expect(ActionMailer::Base.deliveries.count).to be 1
+    context 'index of all open invitations' do
+      it 'sends reminder mail to the invitee as part' do
+        get(grant_invitation_reminders_path(grant))
+        expect(ActionMailer::Base.deliveries.count).to be 1
+      end
+
+      it "updates the invitation's reminded_at attribute" do
+        expect do
+          get(grant_invitation_reminders_path(grant))
+        end.to change{invited.reload.reminded_at}.from nil
+      end
     end
 
-    it "updates the invitation's reminded_at attribute" do
-      expect do
-        get(grant_invitation_reminders_path(grant))
-      end.to change{invited.reload.reminded_at}.from nil
+    context 'one open invitation' do
+      it 'sends reminder mail to the invitee as part' do
+        get(grant_invitation_reminder_path(grant.id, invited))
+        expect(ActionMailer::Base.deliveries.count).to be 1
+      end
+
+      it "updates the invitation's reminded_at attribute" do
+        expect do
+          get(grant_invitation_reminder_path(grant.id, invited))
+        end.to change{invited.reload.reminded_at}.from nil
+      end
     end
+
   end
 end

--- a/spec/system/grant_reviewers/grant_reviewer_invitations_spec.rb
+++ b/spec/system/grant_reviewers/grant_reviewer_invitations_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe GrantReviewer::Invitation, type: :system do
+  include ActionView::RecordIdentifier
+
   let!(:grant)                          { create(:published_open_grant_with_users) }
   let!(:admin)                          { grant.administrators.first }
   let!(:inviter)                        { grant.editors.first }
@@ -64,7 +66,26 @@ RSpec.describe GrantReviewer::Invitation, type: :system do
       end
 
       it 'includes link to send reminder emails' do
-        expect(page).to have_link 'Send Reminder to Invited Reviewers', href: grant_invitation_reminders_path(grant)
+        expect(page).to have_link 'Send Reminder to All Invited Reviewers', href: grant_invitation_reminders_path(grant)
+      end
+
+      it 'includes links to manage the invite' do
+        registered_invite_row = find("tr[data-invite='#{registered_reviewer_invitation.id}']").text(:all)
+        saml_invite_row       = find("tr[data-invite='#{saml_reviewer_invitation.id}']").text(:all)
+
+        expect(registered_invite_row).to have_content 'Manage'
+        expect(saml_invite_row).to have_content 'Manage'
+      end
+
+      it 'can be deleted' do
+        invite_dom_id = "manage-#{dom_id(registered_reviewer_invitation)}"
+        page.find("##{invite_dom_id}").hover
+
+        accept_alert do
+          click_link('Delete')
+        end
+
+        expect(page).to have_content "#{registered_reviewer_invitation.email} has been deleted"
       end
     end
 
@@ -95,6 +116,13 @@ RSpec.describe GrantReviewer::Invitation, type: :system do
         expect(page).to have_text 'There are no open reviewer invitations for this grant. No reminders have been sent'
       end
 
+      it 'does not include links to manage the invite' do
+        registered_invite_row = find("tr[data-invite='#{registered_reviewer_invitation.id}']").text(:all)
+        saml_invite_row       = find("tr[data-invite='#{saml_reviewer_invitation.id}']").text(:all)
+
+        expect(registered_invite_row).not_to have_content 'Manage'
+        expect(saml_invite_row).not_to have_content 'Manage'
+      end
     end
   end
 


### PR DESCRIPTION
Allows grant admins to selectively send reviewer invitation reminders and to delete existing invitations.

Closes #911 
Related to #846 #958