### PR TITLE
Fix flash invitation related flash messages

### DIFF
--- a/app/controllers/grant_reviewers/invitations/reminders_controller.rb
+++ b/app/controllers/grant_reviewers/invitations/reminders_controller.rb
@@ -6,26 +6,27 @@ module GrantReviewers
                               .with_inviter
                               .where(grant_id: @grant.id)
                               .open
-        if @open_invitations.any?
-          send_reminder_emails
-          flash[:notice] = 'Reminder emails have been sent to those who have not yet responded.'
-        else
-          flash[:warning] = 'There are no open reviewer invitations for this grant. No reminders have been sent'
+        respond_to do |format|
+          if @open_invitations.any?
+            send_reminder_emails
+            format.html { redirect_to grant_invitations_url(@grant), notice: 'Reminder emails have been sent to those who have not yet responded.' }
+          else
+            format.html { redirect_to grant_invitations_url(@grant), alert: 'There are no open reviewer invitations for this grant. No reminders have been sent' }
+          end
         end
-        redirect_back fallback_location: grant_invitations_path(@grant)
       end
 
       def show
         invitation = GrantReviewer::Invitation.find(params[:id])
 
-        if invitation.present? && invitation.invitee.nil?
-          send_reminder_email(invitation)
-          flash[:success] = "A reminder has been sent to #{invitation.email}."
-        else
-          flash[:warning] = 'A reminder could not be sent to the selected email address.'
+        respond_to do |format|
+          if invitation.present? && invitation.invitee.nil?
+            send_reminder_email(invitation)
+            format.html { redirect_to grant_invitations_url(@grant), notice: "A reminder has been sent to #{invitation.email}." }
+          else
+            format.html { redirect_to grant_invitations_url(@grant), alert: 'A reminder could not be sent to the selected email address.' }
+          end
         end
-
-        redirect_back fallback_location: grant_invitations_path(@grant)
       end
 
       private

--- a/app/controllers/grant_reviewers/invitations_controller.rb
+++ b/app/controllers/grant_reviewers/invitations_controller.rb
@@ -13,25 +13,27 @@ module GrantReviewers
 
     def create
       invitation = GrantReviewer::Invitation.new(grant: @grant, inviter: current_user, email: params[:email])
-      if invitation.save
-        GrantReviewerInvitationMailer.invite(invitation: invitation, grant: @grant, inviter: current_user).deliver_now
-        flash[:alert] = "Invitation to #{invitation.email} has been sent. #{helpers.link_to 'View all invitations', grant_invitations_path(@grant)}"
-      else
-        flash[:warning] = invitation.errors.full_messages
+
+      respond_to do |format|
+        if invitation.save
+          GrantReviewerInvitationMailer.invite(invitation: invitation, grant: @grant, inviter: current_user).deliver_now
+          format.html { redirect_to grant_reviewers_url(@grant), notice: "Invitation to #{invitation.email} has been sent. #{helpers.link_to 'View all invitations', grant_invitations_path(@grant)}" }
+        else
+          format.html { redirect_to grant_reviewers_url(@grant), warning: invitation.errors.full_messages }
+        end
       end
-      redirect_back fallback_location: grant_reviewers_path(@grant)
     end
 
     def destroy
       invitation = GrantReviewer::Invitation.find(params[:id])
 
-      if invitation.invitee.nil? && invitation.destroy
-        flash[:success] = "The invitation to #{invitation.email} has been deleted."
-      else
-        flash[:warning] = "Could not delete the invitation to #{invitation.email}."
+      respond_to do |format|
+        if invitation.invitee.nil? && invitation.destroy
+          format.html { redirect_to grant_reviewers_url(@grant), notice: "The invitation to #{invitation.email} has been deleted." }
+        else
+          format.html { redirect_to grant_reviewers_url(@grant), warning: "Could not delete the invitation to #{invitation.email}." }
+        end
       end
-
-      redirect_back fallback_location: grant_reviewers_path(@grant)
     end
 
     private

--- a/app/controllers/grant_reviewers_controller.rb
+++ b/app/controllers/grant_reviewers_controller.rb
@@ -15,19 +15,22 @@ class GrantReviewersController < ApplicationController
   def create
     authorize @grant, :edit?
 
-    email   = grant_reviewer_params[:reviewer_email].downcase.strip
+    email    = grant_reviewer_params[:reviewer_email].downcase.strip
     reviewer = User.find_by(email: email)
 
-    if reviewer.nil?
+    # TODO: catch this any other way
+    if email.blank?
+      flash[:alert] = 'Please enter a valid email address.'
+    elsif reviewer.nil?
       flash[:alert] = "Could not find a user with the email: #{email}. #{helpers.link_to 'Invite them to be a reviewer', invite_grant_reviewers_path(@grant, email: email), method: :post, data: { confirm: "An email will be sent to #{email}. You will be notified when they accept or opt out."} }"
     else
       grant_reviewer = GrantReviewer.create(grant: @grant, reviewer: reviewer)
+
       if grant_reviewer.errors.none?
         flash[:success] = "Added #{helpers.full_name(grant_reviewer.reviewer)} as reviewer."
       else
         flash[:alert]   = grant_reviewer.errors.full_messages
       end
-
     end
 
     redirect_to grant_reviewers_path(@grant)

--- a/app/views/grant_reviewers/index.html.haml
+++ b/app/views/grant_reviewers/index.html.haml
@@ -27,7 +27,7 @@
           %div{ style: 'display: inline-block' }
             = form_for :grant_reviewer, url: grant_reviewers_path(@grant) do |f|
               .input-group
-                = f.email_field :reviewer_email, placeholder: 'Email', class: 'input-group-field'
+                = f.email_field :reviewer_email, placeholder: 'Email', class: 'input-group-field', required: true
                 .input-group-button
                   = f.submit 'Look Up', class: 'button small'
         %li

--- a/app/views/grant_reviewers/invitations/_invitation.html.haml
+++ b/app/views/grant_reviewers/invitations/_invitation.html.haml
@@ -11,9 +11,9 @@
     - if invitation.confirmed_at.nil?
       %ul.dropdown.menu{ data: { "dropdown-menu": '' } }
         %li.text
-          = link_to 'Manage', '#', id: "manage-#{dom_id(invitation)}"
+          = link_to 'Manage', '', id: "manage-#{dom_id(invitation)}"
           %ul.menu
             %li
-              = link_to 'Send Reminder', grant_invitation_reminder_url(grant.id, invitation)
-              = link_to 'Delete', grant_invitation_path(grant.id, invitation), method: :delete, data: { confirm: 'This inviation will be deleted and the recipient will need to be invited again.' }
+              = link_to 'Send Reminder', grant_invitation_reminder_url(grant.id, invitation), data: {turbo: false}
+              = link_to 'Delete', grant_invitation_path(grant.id, invitation), method: :delete, data: { turbo: false, confirm: 'This inviation will be deleted and the recipient will need to be invited again.' }
 

--- a/app/views/grant_reviewers/invitations/index.html.haml
+++ b/app/views/grant_reviewers/invitations/index.html.haml
@@ -31,7 +31,7 @@
             Actions:
           - if @has_open_invitations
             %li
-              = link_to 'Send Reminder to All Invited Reviewers', grant_invitation_reminders_path(@grant)
+              = link_to 'Send Reminder to All Invited Reviewers', grant_invitation_reminders_path(@grant), data: {turbo: false}
           %li
             = link_to 'Back to Reviewers', grant_reviewers_path(@grant)
 

--- a/spec/system/grant_reviewers/grant_reviewer_invitations_spec.rb
+++ b/spec/system/grant_reviewers/grant_reviewer_invitations_spec.rb
@@ -87,6 +87,18 @@ RSpec.describe GrantReviewer::Invitation, type: :system do
 
         expect(page).to have_content "#{registered_reviewer_invitation.email} has been deleted"
       end
+
+      it 'displays a reminder email confirmation message' do
+        invite_dom_id = "manage-#{dom_id(saml_reviewer_invitation)}"
+        page.find("##{invite_dom_id}").hover
+        expect(page).to have_link('Send Reminder')
+      end
+
+      it 'displays a delete invitation confirmation message' do
+        invite_dom_id = "manage-#{dom_id(saml_reviewer_invitation)}"
+        page.find("##{invite_dom_id}").hover
+        expect(page).to have_link('Delete')
+      end
     end
 
     context 'confirmed invites' do


### PR DESCRIPTION
- Fixes intermittent instances where flash messages would not appear.
- Quick fixes to prevent an empty email address being submitted to invitation form.

Found during #966 