### PR TITLE
task/disable review form edits after completed reviews

### DIFF
--- a/app/controllers/grants/criteria_controller.rb
+++ b/app/controllers/grants/criteria_controller.rb
@@ -15,7 +15,7 @@ module Grants
       #  current_user does not have grant_editor_access permissions
       #  or
       #  there are completed reviews
-      @disable_fields = !(policy(@grant).grant_editor_access? && @grant.reviews.completed.none?)
+      @editable = (policy(@grant).grant_editor_access? && @grant.reviews.completed.none?)
     end
 
     def update

--- a/app/controllers/grants/criteria_controller.rb
+++ b/app/controllers/grants/criteria_controller.rb
@@ -6,12 +6,23 @@ module Grants
     skip_after_action :verify_policy_scoped, only: %i[index]
 
     def index
+      @grant = Grant.includes(:reviews, :criteria).kept.friendly.find(params[:id])
+
       authorize @grant, :grant_viewer_access?
+
       @criteria = @grant.criteria.order(:created_at)
+      # disable_fields == true when either:
+      #  current_user does not have grant_editor_access permissions
+      #  or
+      #  there are completed reviews
+      @disable_fields = !(policy(@grant).grant_editor_access? && @grant.reviews.completed.none?)
     end
 
     def update
+      @grant = Grant.kept.friendly.find(params[:id])
+
       authorize @grant, :edit?
+
       if @grant.update(grant_params)
         flash[:notice] = 'Review form and criteria updated.'
         redirect_to criteria_grant_path(@grant)
@@ -22,10 +33,6 @@ module Grants
     end
 
     private
-
-    def set_grant
-      @grant = Grant.kept.friendly.find(params[:id])
-    end
 
     def grant_params
       params.require(:grant).permit(

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -8,9 +8,15 @@ class Criterion < ApplicationRecord
                         Approach
                         Environment].freeze
 
-  belongs_to :grant,            inverse_of: :criteria
+  belongs_to :grant, inverse_of: :criteria
   has_many   :criteria_reviews, dependent: :destroy
 
   validates_presence_of :name
   validates :name, uniqueness: { scope: :grant }
+
+  validate :grant_may_not_have_completed_reviews, on: :create, if: -> () { grant.present? && grant.reviews.completed.any? }
+
+  def grant_may_not_have_completed_reviews
+    errors.add(:base, :may_not_change_criterion_after_reviews_submitted)
+  end
 end

--- a/app/views/grants/criteria/_criterion_fields.html.haml
+++ b/app/views/grants/criteria/_criterion_fields.html.haml
@@ -1,29 +1,27 @@
-- disable_fields = !policy(@grant).update?
-
 .nested-fields
   .field
     .grid-x
       .cell.small-12.medium-2
         = f.label :name
       .cell.small-12.medium-9.medium-offset-1
-        = f.text_field :name, width: 50, required: true, disabled: disable_fields
+        = f.text_field :name, width: 50, required: true, disabled: @disable_fields
   .field
     .grid-x
       .cell.small-12.medium-2
         = f.label :description
       .cell.small-12.medium-9.medium-offset-1
-        = f.text_area :description, width: 50, disabled: disable_fields
+        = f.text_area :description, width: 50, disabled: @disable_fields
   .field
     .grid-x
       .cell.small-12.medium-offset-3
-        = f.check_box :is_mandatory, disabled: disable_fields
+        = f.check_box :is_mandatory, disabled: @disable_fields
         = f.label :is_mandatory
         %br
-        = f.check_box :show_comment_field, disabled: disable_fields
+        = f.check_box :show_comment_field, disabled: @disable_fields
         = f.label :show_comment_field
 
   .field
     .grid-x
-      = link_to_remove_association 'Remove', f, class: 'button tiny hollow alert remove' unless disable_fields
+      = link_to_remove_association 'Remove', f, class: 'button tiny hollow alert remove' unless @disable_fields
 
   %hr

--- a/app/views/grants/criteria/_criterion_fields.html.haml
+++ b/app/views/grants/criteria/_criterion_fields.html.haml
@@ -4,24 +4,24 @@
       .cell.small-12.medium-2
         = f.label :name
       .cell.small-12.medium-9.medium-offset-1
-        = f.text_field :name, width: 50, required: true, disabled: @disable_fields
+        = f.text_field :name, width: 50, required: true, disabled: !@editable
   .field
     .grid-x
       .cell.small-12.medium-2
         = f.label :description
       .cell.small-12.medium-9.medium-offset-1
-        = f.text_area :description, width: 50, disabled: @disable_fields
+        = f.text_area :description, width: 50, disabled: !@editable
   .field
     .grid-x
       .cell.small-12.medium-offset-3
-        = f.check_box :is_mandatory, disabled: @disable_fields
+        = f.check_box :is_mandatory, disabled: !@editable
         = f.label :is_mandatory
         %br
-        = f.check_box :show_comment_field, disabled: @disable_fields
+        = f.check_box :show_comment_field, disabled: !@editable
         = f.label :show_comment_field
 
   .field
     .grid-x
-      = link_to_remove_association 'Remove', f, class: 'button tiny hollow alert remove' unless @disable_fields
+      = link_to_remove_association 'Remove', f, class: 'button tiny hollow alert remove' unless !@editable
 
   %hr

--- a/app/views/grants/criteria/index.html.haml
+++ b/app/views/grants/criteria/index.html.haml
@@ -53,16 +53,16 @@
       #criteria.grid-x
         .cell
           = f.fields_for :criteria, @criteria do |criterion|
-            = render partial: 'criterion_fields', locals: { f: criterion }
+            = render partial: 'grants/criteria/criterion_fields', locals: { f: criterion }
 
           
-      - unless @disable_fields
+      - if @editable
         .links
           = link_to_add_association 'Add a New Review Criterion', f, :criteria, class: 'button hollow small'
 
       .cell.overall_impact_score
         = render partial: 'overall_impact_fields'
 
-      - unless @disable_fields        
+      - if @editable        
         .cell
           = f.submit 'Save Changes', class: 'button'

--- a/app/views/grants/criteria/index.html.haml
+++ b/app/views/grants/criteria/index.html.haml
@@ -1,7 +1,5 @@
 - content_for(:page_title, 'Edit Review Form')
 
-- disable_fields = !policy(@grant).grant_editor_access?
-
 = render 'shared/grant_header', { grant: @grant, section_title: 'Review Form' }
 
 .grid-x
@@ -19,6 +17,10 @@
 = render 'shared/grant_edit_tabbed_menu', { grant: @grant }
 
 .tabs-panel.is-active
+  - if @grant.reviews.completed.any?
+    %div.callout.warning
+      This form is locked because #{@grant.reviews.one? ? 'a review has' : 'reviews have' } already been submitted.
+
   = form_for @grant, url: update_criteria_grant_path(@grant), local: true, data: { turbo: false } do |f|
     .grid-x
       .cell
@@ -53,14 +55,14 @@
           = f.fields_for :criteria, @criteria do |criterion|
             = render partial: 'criterion_fields', locals: { f: criterion }
 
-      - unless disable_fields
+          
+      - unless @disable_fields
         .links
           = link_to_add_association 'Add a New Review Criterion', f, :criteria, class: 'button hollow small'
 
+      .cell.overall_impact_score
+        = render partial: 'overall_impact_fields'
 
-        .cell.overall_impact_score
-          = render partial: 'overall_impact_fields'
-
-
+      - unless @disable_fields        
         .cell
           = f.submit 'Save Changes', class: 'button'

--- a/config/locales/activerecord/criterion.yml
+++ b/config/locales/activerecord/criterion.yml
@@ -9,6 +9,7 @@ en:
     errors:
       models:
         criterion:
+          may_not_change_criterion_after_reviews_submitted: This grant has recieved completed reviews. Its review criteria cannot be changed. 
           attributes:
   helpers:
     label:

--- a/config/locales/activerecord/grant.en.yml
+++ b/config/locales/activerecord/grant.en.yml
@@ -7,11 +7,14 @@ en:
         publish_date: Publish Date
         submission_open_date: Submission Open Date
         submission_close_date: Submission Close Date
+        review_open_date: Review Open Date
         review_close_date: Review Close Date
     errors:
       models:
         grant:
-          <<: *grant
+          attributes:
+            <<: *grant
+          invalid_date: is not valid.
     models:
       grant:
         one: grant

--- a/spec/models/criterion_spec.rb
+++ b/spec/models/criterion_spec.rb
@@ -9,8 +9,14 @@ RSpec.describe Criterion, type: :model do
   it { is_expected.to respond_to(:criteria_reviews) }
 
   context '#validations' do
-    let(:grant)     { create(:grant) }
-    let(:criterion) { build(:criterion, grant: grant) }
+    let(:grant)       { create(:published_open_grant_with_users, :with_reviewer) }
+    let(:criterion)   { build(:criterion, grant: grant) }
+    let(:submission)  { create(:submission_with_responses, grant: grant) }
+    let(:review)      { create(:scored_review_with_scored_mandatory_criteria_review, 
+                                        submission: submission,
+                                        reviewer: grant.reviewers.first,
+                                        assigner: grant.admins.first,
+                                        overall_impact_score: 5) }
 
     it 'validates a valid criterion' do
       expect(criterion).to be_valid
@@ -33,6 +39,14 @@ RSpec.describe Criterion, type: :model do
         @other_criterion = create(:criterion, grant: grant)
         criterion.name = @other_criterion.name
         expect(criterion).not_to be_valid
+      end
+    end
+
+    context '#with_submitted_reviews' do
+      it 'is not valid when there is a submitted review' do
+        review.touch
+        expect(criterion).not_to be_valid
+        expect(criterion.errors.full_messages).to include I18n.t('activerecord.errors.models.criterion.may_not_change_criterion_after_reviews_submitted')
       end
     end
   end

--- a/spec/services/grant_services/duplicate_spec.rb
+++ b/spec/services/grant_services/duplicate_spec.rb
@@ -4,73 +4,77 @@ require 'rails_helper'
 
 RSpec.describe GrantServices do
   describe 'DuplicateDependencies' do
+    let(:original_grant) { create(:published_open_grant_with_users) }
+    let(:new_grant)      { build(:grant, duplicate: true,
+                                         name: "New #{original_grant.name}",
+                                         slug: "New#{original_grant.slug}") }
+    let(:invalid_grant)  { build(:grant, name: '') }
+
     before(:each) do
-      @original_grant = create(:grant_with_users)
-      @new_grant      = create(:grant,  duplicate: true,
-                                        name: 'New Name',
-                                        slug: 'NewShort')
-      @invalid_grant  = build(:grant, name: '')
+      original_grant.touch
     end
 
     context 'valid grant' do
       it 'returns :success? true on successful duplication' do
-        result = GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @new_grant)
+        result = GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: new_grant)
         expect(result.success?).to eql(true)
       end
 
-      it 'returns :success? false on successful duplication' do
-        result = GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @invalid_grant)
-        expect(result.success?).to eql(false)
-      end
-
       it 'duplicates grant_permissions for valid new grant' do
-        new_grant_permission_count = @original_grant.grant_permissions.count
+        new_grant_permission_count = original_grant.grant_permissions.count
 
         expect do
-          GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @new_grant)
-        end.to (change{GrantPermission.count}.by (new_grant_permission_count))
+          GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: new_grant)
+        end.to (change{ GrantPermission.count }.by (new_grant_permission_count))
       end
 
       it 'duplicates criteria for valid new grant' do
-        new_criteria_count = @original_grant.criteria.count
-
         expect do
-          GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @new_grant)
-        end.to (change{Criterion.count}.by (new_criteria_count))
+          GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: new_grant)
+        end.to (change{ Criterion.count }.by (original_grant.criteria.count))
       end
 
       it 'duplicates grant_submission_form for valid new grant' do
         expect do
-          GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @new_grant)
-        end.to (change{GrantSubmission::Form.count}.by (1))
+          GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: new_grant)
+        end.to (change{ GrantSubmission::Form.count }.by (1))
       end
 
       context 'panels' do
         it 'duplicates panel for valid new grant' do
           expect do
-            GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @new_grant)
-          end.to (change{Panel.count}.by (1))
+            GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: new_grant)
+          end.to (change{ Panel.count }.by (1))
         end
 
         it 'clears dates from duplicated panel' do
-          GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @new_grant)
-          expect(Panel.last.start_datetime).to be nil
-          expect(Panel.last.end_datetime).to be nil
+          GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: new_grant)
+          expect(new_grant.panel.start_datetime).to be nil
+          expect(new_grant.panel.end_datetime).to be nil
         end
       end
     end
 
     context 'invalid grant' do
-      it 'does not duplicate grant_permissions' do
-        result =  GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @invalid_grant)
+      it 'returns :success? false on failed duplication' do
+        result = GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: invalid_grant)
         expect(result.success?).to eql(false)
-        expect(@invalid_grant.grant_permissions.count).to eql(0)
+      end
+
+      it 'does not duplicate grant_permissions' do
+        expect do
+          result =  GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: invalid_grant)
+          expect(result.success?).to eql(false)
+          expect(invalid_grant.grant_permissions.count).to eql(0)
+        end.not_to (change{ GrantPermission.count })
       end
 
       it 'does not duplicate criteria' do
-        result =  GrantServices::DuplicateDependencies.call(original_grant: @original_grant, new_grant: @invalid_grant)
-        expect(result.success?).to eql(false)
-        expect(@invalid_grant.criteria.count).to eql(0)
+        expect do
+          result =  GrantServices::DuplicateDependencies.call(original_grant: original_grant, new_grant: invalid_grant)
+          expect(result.success?).to eql(false)
+          expect(invalid_grant.criteria.count).to eql(0)
+        end.not_to (change{ Criterion.count })
       end
     end
   end

--- a/spec/system/grant_submissions/grant_submission_submission_applicants_spec.rb
+++ b/spec/system/grant_submissions/grant_submission_submission_applicants_spec.rb
@@ -409,11 +409,13 @@ RSpec.describe 'GrantSubmission::Submission SubmissionApplicants', type: :system
               expect(page).not_to have_text(new_applicant.email)
               find_field(id: 'grant_submission_submission_applicant_applicant_email').set(new_applicant.email)
               click_button 'Look Up'
+              pause
               expect(page).to have_text("#{new_applicant.first_name} #{new_applicant.last_name} was added as applicant on #{draft_submission.title}.")
               expect(page).to have_text(new_applicant.email)
 
               find_field(id: 'grant_submission_submission_applicant_applicant_email').set(new_applicant.email)
               click_button 'Look Up'
+              pause
               expect(page).to have_text("Applicant #{full_name(new_applicant)} is already on the submission, #{draft_submission.title}")
             end
           end

--- a/spec/system/grants/criteria_spec.rb
+++ b/spec/system/grants/criteria_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe 'Criteria', type: :system, js: true do
     scenario 'grant with reviews is not editable' do
       review.touch
       login_as(admin2, scope: :saml_user)
+
       visit criteria_grant_path(grant_with_submission)
       criterion = grant_with_submission.criteria.first
       expect(page).to have_content 'This form is locked because a review has already been submitted'

--- a/spec/system/grants/criteria_spec.rb
+++ b/spec/system/grants/criteria_spec.rb
@@ -3,24 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe 'Criteria', type: :system, js: true do
-  describe 'Index' do
-    let(:grant) { create(:draft_grant) }
-    let(:admin) { grant.administrators.first }
+  let(:grant)   { create(:draft_grant) }
+  let(:admin)   { grant.administrators.first }
+  
+  let(:grant_with_submission) { create(:open_grant_with_users_and_form_and_submission_and_reviewer, review_open_date: Date.current) }
+  let(:admin2)  { grant_with_submission.administrators.first }
+  let(:review)  { create(:scored_review_with_scored_mandatory_criteria_review, submission: grant_with_submission.submissions.first,
+                                                                               reviewer: grant_with_submission.reviewers.first,
+                                                                               assigner: admin2) }
 
+  context '#index' do
+    scenario "it displays the grant's criteria" do
+      login_as(admin, scope: :saml_user)
+      visit criteria_grant_path(grant)
+
+      grant.criteria.each do |criterion|
+        expect(page).to have_field('Criterion Name', with: criterion.name)
+      end
+    end
+  end
+
+  context '#update' do
     before(:each) do
       login_as(admin, scope: :saml_user)
       visit criteria_grant_path(grant)
     end
 
-    context '#index' do
-      scenario "it displays the grant's criteria" do
-        grant.criteria.each do |criterion|
-          expect(page).to have_field('Criterion Name', with: criterion.name)
-        end
-      end
-    end
-
-    context '#update' do
+    context '#criterion' do 
       scenario 'it deletes a criterion' do
         expect do
           find('.remove', match: :first).click
@@ -70,15 +79,35 @@ RSpec.describe 'Criteria', type: :system, js: true do
         end.not_to change{grant.criteria.count}
         expect(page).to have_content 'Must have at least one review criteria.'
       end
+    end
+  end
 
-      context 'paper_trail', versioning: true do
-        scenario 'it tracks whodunnit' do
-          find_field('Criterion Name', with: grant.criteria.last.name).set(Faker::Lorem.sentence)
-          click_button 'Save'
-          pause
-          expect(grant.criteria.last.versions.last.whodunnit).to be admin.id
-        end
-      end
+  context '#diabled_fields' do
+    scenario 'grant without reviews is editable' do
+      login_as(admin2, scope: :saml_user)
+      criterion = grant_with_submission.criteria.first
+      visit criteria_grant_path(grant_with_submission)
+      expect(page).not_to have_content 'This form is locked because a review has already been submitted'
+    end
+
+    scenario 'grant with reviews is not editable' do
+      review.touch
+      login_as(admin2, scope: :saml_user)
+      visit criteria_grant_path(grant_with_submission)
+      criterion = grant_with_submission.criteria.first
+      expect(page).to have_content 'This form is locked because a review has already been submitted'
+    end
+  end
+
+  context 'paper_trail', versioning: true do
+    scenario 'it tracks whodunnit' do
+      login_as(admin, scope: :saml_user)
+      visit criteria_grant_path(grant)
+
+      find_field('Criterion Name', with: grant.criteria.last.name).set(Faker::Lorem.sentence)
+      click_button 'Save'
+
+      expect(grant.criteria.last.versions.last.whodunnit).to be admin.id
     end
   end
 end


### PR DESCRIPTION
Related to #1014 

Disable the review criteria form after the grant has received a completed review. 