### PR TITLE
Task/fix grant redirect on slug change

### DIFF
--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -62,7 +62,8 @@ class GrantsController < ApplicationController
     authorize @grant
     if @grant.update(grant_params)
       flash[:notice] = 'Grant was successfully updated.'
-      redirect_back(fallback_location: grant_path(@grant))
+
+      redirect_to edit_grant_path(@grant.reload)
     else
       flash.now[:alert] = @grant.errors.full_messages
       render :edit

--- a/app/controllers/grants_controller.rb
+++ b/app/controllers/grants_controller.rb
@@ -20,9 +20,7 @@ class GrantsController < ApplicationController
     flash.keep
     @grant = Grant.includes(:contacts).kept.friendly.find(params[:id])
 
-    if authorize @grant
-      draft_banner
-    end
+    draft_banner if authorize @grant
   end
 
   # GET /grants/new
@@ -102,13 +100,14 @@ class GrantsController < ApplicationController
       :max_submissions_per_reviewer,
       :panel_date,
       :panel_location,
-      criteria_attributes: [
-        :id,
-        :name,
-        :description,
-        :is_mandatory,
-        :show_comment_field,
-        :_destroy]
+      criteria_attributes: %i[
+        id
+        name  
+        description
+        is_mandatory
+        show_comment_field
+        _destroy
+      ]
     )
   end
 

--- a/spec/system/grants/grants_spec.rb
+++ b/spec/system/grants/grants_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe 'Grants', type: :system, js: true do
 
     context 'editor' do
       before(:each) do
-        @grant          = create(:grant_with_users)
-        @editor_user     = @grant.grant_permissions.role_editor.first.user
+        @grant = create(:grant_with_users)
+        @editor_user = @grant.grant_permissions.role_editor.first.user
 
         login_user @editor_user
         visit edit_grant_path(@grant)
@@ -108,8 +108,8 @@ RSpec.describe 'Grants', type: :system, js: true do
 
     context 'viewer' do
       before(:each) do
-        @grant          = create(:grant_with_users)
-        @viewer_user     = @grant.grant_permissions.role_viewer.first.user
+        @grant = create(:grant_with_users)
+        @viewer_user = @grant.grant_permissions.role_viewer.first.user
 
         login_user @viewer_user
         visit edit_grant_path(@grant)
@@ -216,7 +216,7 @@ RSpec.describe 'Grants', type: :system, js: true do
 
           expect(page).to have_button REGISTERED_USER_LOGIN_BUTTON_TEXT
           click_button REGISTERED_USER_LOGIN_BUTTON_TEXT
-          expect(current_path).to eq("/registered_users/sign_in")
+          expect(current_path).to eq('/registered_users/sign_in')
 
           fill_in 'Email address', with: registered_submitter.email
           fill_in 'Password', with: registered_submitter.password
@@ -385,7 +385,7 @@ RSpec.describe 'Grants', type: :system, js: true do
           visit grant_path(grant)
           within('div#grant-contacts') do
             expect(page).to have_text 'Contact'
-            expect(page).to have_content "#{full_name(contact.user)}"
+            expect(page).to have_content full_name(contact.user).to_s
             expect(page).to have_link contact.user.email
           end
         end
@@ -401,9 +401,9 @@ RSpec.describe 'Grants', type: :system, js: true do
           visit grant_path(grant)
           within('div#grant-contacts') do
             expect(page).to have_text 'Contacts'
-            expect(page).to have_content "#{full_name(contact.user)}"
+            expect(page).to have_content full_name(contact.user).to_s
             expect(page).to have_link contact.user.email
-            expect(page).to have_content "#{full_name(contact2.user)}"
+            expect(page).to have_content full_name(contact2.user).to_s
             expect(page).to have_link contact2.user.email
           end
         end
@@ -437,10 +437,6 @@ RSpec.describe 'Grants', type: :system, js: true do
       expect(grant.reload.discarded?).to be false
     end
 
-    pending 'delete button hidden when not discardable' do
-      fail '#TODO: logic to display the delete button?'
-    end
-
     scenario 'draft grant can be soft deleted' do
       grant.update!(state: 'draft')
       visit edit_grant_path(grant)
@@ -470,7 +466,7 @@ RSpec.describe 'Grants', type: :system, js: true do
       @grant_reviewer = @grant.reviewers.first
       @system_admin = create(:system_admin_saml_user)
 
-      @grant_permission   = @grant.grant_permissions.role_editor.first
+      @grant_permission = @grant.grant_permissions.role_editor.first
     end
 
     context 'anoymous user' do
@@ -500,7 +496,6 @@ RSpec.describe 'Grants', type: :system, js: true do
         visit grant_path(@grant)
         expect(page).to have_content authorization_error_text
       end
-
     end
 
     context 'system admin' do

--- a/spec/system/grants/grants_spec.rb
+++ b/spec/system/grants/grants_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe 'Grants', type: :system, js: true do
     end
   end
 
+  describe 'Draft Grant' do
+    let(:draft_grant) { create(:draft_grant) }
+    
+    context 'draft banner' do
+      before(:each) do
+        login_as draft_grant.admins.first
+      end
+
+      scenario 'it shows the draft banner warning' do
+        visit grant_path(draft_grant)
+        expect(page).to have_content 'You must publish this grant to make it available to the public.'
+      end
+
+      scenario 'it removes the draft banner warning on publish' do
+        visit edit_grant_path(draft_grant)
+        click_link 'Publish this Grant'
+        visit grant_path(draft_grant)
+        expect(page).not_to have_content 'You must publish this grant to make it available to the public.'
+      end
+    end
+  end
+
   describe 'Edit' do
     context 'admin' do
       let(:grant) { create(:grant_with_users) }

--- a/spec/system/grants/state_spec.rb
+++ b/spec/system/grants/state_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe 'Grants', type: :system do
 
       scenario 'current status and change status button are shown' do
         expect(page).to have_selector '#grant-state .current', text: 'Draft'
-        # expect(page).to have_content 'Current Publish Status: Draft'
         expect(page).to have_link 'Publish this Grant'
       end
 
@@ -100,7 +99,6 @@ RSpec.describe 'Grants', type: :system do
         @draft_grant.questions.each { |q| q.destroy! }
         click_link 'Publish this Grant'
         expect(page).to have_selector '#grant-state .current', text: 'Draft'
-        # expect(page).to have_content 'Current Publish Status: Draft'
         expect(page).to have_content 'Status change failed.'
       end
 


### PR DESCRIPTION
Closes #1051 

Fixes redirect on change to the grant's friendly URL.