### PR TITLE
Release 1.21.2 (#1080)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.6)
+    rexml (3.3.7)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)

--- a/app/views/devise/menu/_login_items.html.haml
+++ b/app/views/devise/menu/_login_items.html.haml
@@ -23,5 +23,5 @@
         %li
           = button_to 'Log Out', destroy_saml_user_session_path, method: :delete, data: { turbo: "false" }, class: 'devise-dropdown-list-button button expanded'
 - else
-  %li
+  %li#log-in
     = button_to 'Log In', login_index_path, method: :get, data: { turbo: "false" }, class: 'devise-login-button button expanded'

--- a/app/views/documentation/release/index.html.haml
+++ b/app/views/documentation/release/index.html.haml
@@ -6,6 +6,17 @@
 
 %ul.accordion{"data-accordion" => "", "data-allow-all-closed" => "true", "data-multi-expand" => "false"}
   %li.accordion-item.is-active{"data-accordion-item" => ""}
+    %a.accordion-title{:href => "#"} 1.21.2 (September 4, 2024)
+    .accordion-content{"data-tab-content" => ""}
+      %ul
+        %li
+          Fix SAML log out.
+          #{github_issue_link(issue: 1076)}
+        %li
+          Update rexml ruby gem.
+        %li
+          Upgrade trix yarn package.
+  %li.accordion-item{"data-accordion-item" => ""}
     %a.accordion-title{:href => "#"} 1.21.1 (August 7, 2024)
     .accordion-content{"data-tab-content" => ""}
       %ul

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,12 @@ module Competitions
     config.active_record.yaml_column_permitted_classes = [Symbol, Time]
   
     config.active_support.disable_to_s_conversion = true
+
+    # Fixes #1076 - Fix SAML logout
+    #               https://github.com/heartcombo/devise/pull/5462
+    #               https://github.com/apokalipto/devise_saml_authenticatable/issues/237
+    # Review this setting in future rails upgrades
+    config.action_controller.raise_on_open_redirects = false
   end
 end
 

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 module Competitions
   class Application
-    VERSION = '1.21.1'
+    VERSION = '1.21.2'
   end
 end

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "motion-ui": "^2.0.3",
     "select2": "^4.1.0-rc.0",
     "tom-select": "^2.2.2",
-    "trix": "^2.0.8"
+    "trix": "^2.1.5"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --outdir=app/assets/builds"

--- a/spec/system/users/saml_users_spec.rb
+++ b/spec/system/users/saml_users_spec.rb
@@ -71,15 +71,21 @@ RSpec.describe 'SamlUsers', type: :system, js: true  do
       end
     end
 
-    describe 'sign in saml user' do
-      scenario 'user sign in' do
+    context 'devise' do
+      before(:each) do
         login_as(user, scope: :saml_user)
         visit(root_path)
+      end
+
+      scenario 'user signed in' do
         expect(page).to have_content("#{user.first_name} #{user.last_name}")
       end
 
-      pending 'user sign out' do
-        fail '#TODO: test whether saml user can signout'
+      scenario 'user sign out' do
+        # note: requires local SAML IDP
+        page.find('#logged-in').hover
+        click_button('Log Out')
+        expect(page).to have_content('Log In')
       end
     end
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,7 +236,7 @@ tom-select@^2.2.2:
     "@orchidjs/sifter" "^1.0.3"
     "@orchidjs/unicode-variants" "^1.0.4"
 
-trix@^2.0.8:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/trix/-/trix-2.1.3.tgz#38c8725cd1864ca5e9784aed7d043fa11669ba81"
-  integrity sha512-LqMp67LiKMQytAHKqNL1Jgmfz69ViW+WBOQTPA2BlMIuxic1mw5vHgDtOE0bvvojUdjAxh0EJtLpJn6BC/2JKw==
+trix@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-2.1.5.tgz#512bc811172bea196de4a92fa8308c0914f263f9"
+  integrity sha512-5pC4olCp7BwxTC8Joy1Kv33kDvSOApi9Tqf6c8wygqCgeCx9xPP5cxkZEhvKpMV+kjd9gszingd5fZo834+ktw==


### PR DESCRIPTION
* 1076 devise saml logout (#1077)

* Bypass UnsafeRedirectError on SAML logout #1076

* Update specs for SAML logout #1076

* Add comment regarding spec setup/requirement #1076

* Update trix #1074 (#1078)

* Upgrade trix to the latest version.

* 1075 update rexml to latest version (#1079)

* Update release version and notes